### PR TITLE
Add new --reset-to-remote parameter for update

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,9 +37,13 @@ const cli = meow(
         
         repos <subcommand> [--force]
             Handles repo specific actions where <subcommand> is one of the following:
-            --update|-u [--nofetch]:
+            --update|-u [--nofetch] [--reset-to-remote]:
                 Updates all parent repos.
                 If <force> is set the update will take place even if the working copies of the parent repos are not clean.
+                    WARNING: Uncommited changes WILL BE LOST.
+                If <resetToRemote> is set then the update will do a hard reset in order to make sure the local copy
+                matches the remote repository state.
+                    WARNING: Committed but not pushed changes WILL BE LOST.
             --write|-w [--freeze]:
                 Write the states of the parent repos to parent-repos.json.
                 If <freeze> is set the exact commit hashes of the currently checked out parent repos will be written regardless

--- a/src/commands/repos/UpdateRepos.ts
+++ b/src/commands/repos/UpdateRepos.ts
@@ -9,8 +9,10 @@ import {Global} from '../../Global';
 
 export class UpdateRepos extends AbstractReposCommand {
     private static readonly PARAMETER_NO_FETCH: string = 'nofetch';
+    private static readonly PARAMETER_RESET_TO_REMOTE: string = 'resetToRemote';
 
     protected noFetch: boolean;
+    protected resetToRemote: boolean;
 
     public execute(): Promise<void> {
         return Promise.each(
@@ -25,6 +27,10 @@ export class UpdateRepos extends AbstractReposCommand {
         this.noFetch = params[UpdateRepos.PARAMETER_NO_FETCH] as boolean;
         if (this.noFetch) {
             Global.isVerbose() && console.log('running in nofetch mode');
+        }
+        this.resetToRemote = params[UpdateRepos.PARAMETER_RESET_TO_REMOTE] as boolean;
+        if (this.resetToRemote) {
+            Global.isVerbose() && console.log('ATTENTION: resetting to remote state!');
         }
         return true;
     }
@@ -51,6 +57,8 @@ export class UpdateRepos extends AbstractReposCommand {
             .then(() => {
                 if (commit) {
                     return repo.checkoutCommit(commit);
+                } else if (this.resetToRemote) {
+                    return repo.resetHard(branch);
                 } else {
                     return repo.pullOnlyFastForward();
                 }

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -74,8 +74,8 @@ export class Repository {
             const pathSpec = `${fromHash}..${toHash}`;
             options[pathSpec] = null;
             this.git.log(options, (err, data: IGitLogSummary) => {
-                    err ? reject(err) : resolve(data);
-                }
+                             err ? reject(err) : resolve(data);
+                         }
             );
         });
     }
@@ -255,9 +255,12 @@ export class Repository {
             });
     }
 
-    public resetHard(): Promise<void> {
+    public resetHard(branch?: string): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            this.git.reset('hard', (err) => {
+            const args = !branch
+                ? ['--hard']
+                : ['--hard', `origin/${branch}`];
+            this.git.reset(args, (err) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -370,7 +373,7 @@ export class Repository {
                         } else {
                             if (branches[0] === branchAndCommit.branch) {
                                 console.log('WARNING: There are multiple branches at commit ' + branchAndCommit.commit + ': ' + branches +
-                                    ', ignoring branch ' + branchAndCommit.branch);
+                                                ', ignoring branch ' + branchAndCommit.branch);
                                 return true;
                             } else {
                                 return false;


### PR DESCRIPTION
Allows to reset a repository's branch to the current remote state. This allows circumventing errors occurring when a force push has happened to a branch and the local repository cache still has now-gone commits.