### PR TITLE
Add new specs and noInstall parameter

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,7 +95,7 @@ const cli = meow(`
                 Will refactor an old plugin source structure like 'src/classes' or 'src/java' to a proper Maven-like structure with
                 'src/main/java' and 'src/test/java'
         
-        e2e [--baseUrl <baseUrl>] [--context <context>] [--tenantId <tenantId>] [--e2eToken <token>] [--browser <browser>] [--plugins <plugins>] [--timeout <timeout>] [--headless]
+        e2e [--baseUrl <baseUrl>] [--context <context>] [--tenantId <tenantId>] [--e2eToken <token>] [--browser <browser>] [--plugins <plugins>] [--specs <specs>] [--timeout <timeout>] [--headless] [--noInstall]
         
             --baseUrl to configure where to run the tests against (default: 'http://localhost:8083')
             --context to define in which context cplace is running (default: '/intern/tricia/')
@@ -103,8 +103,10 @@ const cli = meow(`
             --e2eToken to define the Test Setup Handler E2E token (default: '')
             --browser to specify which browser to use (default: Chrome)
             --plugins to specify a comma separated list of plugins to run tests for (default: all plugins in the current repository)
+            --specs to specify the pattern used to search for specification files inside plugins (default: '**/*.spec.ts')
             --timeout to specify a global Timeout for Test Execution
             --headless currently only possible in Chrome
+            --noInstall will skip the check for new Selenium Drivers (required to run offline, default: false)
             
 
     Global options:

--- a/src/commands/e2e/ConfigTemplate.ts
+++ b/src/commands/e2e/ConfigTemplate.ts
@@ -1,7 +1,9 @@
 export class ConfigTemplate {
     private readonly template: string;
 
-    constructor(mainRepoDir: string, e2eFolder: string, browser: string, baseUrl: string, timeout: number, headless: boolean) {
+    constructor(mainRepoDir: string, e2eFolder: string,
+                specs: string, browser: string, baseUrl: string,
+                timeout: number, headless: boolean, noInstall: boolean) {
         let capabilities = '';
         if (headless) {
             capabilities = `
@@ -37,7 +39,7 @@ export class ConfigTemplate {
             },
             runner: 'local',
             specs: [
-                '${e2eFolder}/specs/**/*.spec.ts'
+                '${e2eFolder}/specs/${specs || '**/*.spec.ts'}'
             ],
             exclude: [],
             maxInstances: 1,
@@ -49,6 +51,7 @@ export class ConfigTemplate {
             connectionRetryTimeout: 90000,
             connectionRetryCount: 3,
             services: ['selenium-standalone', 'intercept'],
+            skipSeleniumInstall: ${noInstall ? 'true' : 'false'},
             framework: 'jasmine',
             jasmineNodeOpts: {
                 defaultTimeoutInterval: ${timeout}

--- a/src/commands/e2e/E2E.ts
+++ b/src/commands/e2e/E2E.ts
@@ -17,9 +17,12 @@ export class E2E implements ICommand {
     private static readonly PARAMETER_E2E_TOKEN: string = 'e2eToken';
 
     private static readonly PARAMETER_PLUGINS: string = 'plugins';
+    private static readonly PARAMETER_SPECS: string = 'specs';
     private static readonly PARAMETER_BROWSER: string = 'browser';
     private static readonly PARAMETER_TIMEOUT: string = 'timeout';
     private static readonly PARAMETER_HEADLESS: string = 'headless';
+    private static readonly PARAMETER_NO_INSTALL: string = 'noInstall';
+
     // Default
     private static readonly DEFAULT_BASE_URL: string = 'http://localhost:8083';
     private static readonly DEFAULT_CONTEXT: string = '/intern/tricia/';
@@ -34,10 +37,12 @@ export class E2E implements ICommand {
     private tenantId: string;
     private e2eToken: string;
 
-    private pluginsToBeTested: string [];
+    private pluginsToBeTested: string[];
+    private specs: string;
     private browser: string;
     private timeout: number;
     private headless: boolean;
+    private noInstall: boolean;
 
     private testRunner: TestRunner | null = null;
 
@@ -61,6 +66,11 @@ export class E2E implements ICommand {
         }
 
         console.log('Running E2E tests for: ', this.pluginsToBeTested.join(', '));
+
+        const specs = params[E2E.PARAMETER_SPECS];
+        if (typeof specs === 'string' && specs.length > 0) {
+            this.specs = specs;
+        }
 
         // NOTE: The slashes of baseUrl and context need to match the
         // specifications required by the cplace base system. Also see the E2EENV
@@ -122,6 +132,13 @@ export class E2E implements ICommand {
             this.headless = headless;
         }
 
+        const noInstall = params[E2E.PARAMETER_NO_INSTALL];
+        if (typeof noInstall === 'boolean') {
+            this.noInstall = noInstall;
+        } else {
+            this.noInstall = false;
+        }
+
         if (this.browser.toLowerCase() !== 'chrome') {
             this.headless = false;
             console.error(`! Headless disabled - only available for Chrome execution`);
@@ -150,8 +167,8 @@ export class E2E implements ICommand {
 
         const wdioGenerator = new WdioConfigGenerator(
             this.workingDir, this.mainRepoDir,
-            this.pluginsToBeTested, this.browser, context,
-            this.timeout, this.headless
+            this.pluginsToBeTested, this.specs, this.browser, context,
+            this.timeout, this.headless, this.noInstall
         );
 
         console.log('Generating WDIO configuration files...');

--- a/src/commands/e2e/WdioConfigGenerator.ts
+++ b/src/commands/e2e/WdioConfigGenerator.ts
@@ -11,18 +11,24 @@ export class WdioConfigGenerator {
     private readonly mainDir: string;
     private readonly context: IE2EContext;
     private readonly plugins: string[];
+    private readonly specs: string;
     private readonly browser: string;
     private readonly timeout: number;
     private readonly headless: boolean;
+    private readonly noInstall: boolean;
 
-    constructor(workingDir: string, mainDir: string, plugins: string[], browser: string, context: IE2EContext, timeout: number, headless: boolean) {
+    constructor(workingDir: string, mainDir: string,
+                plugins: string[], specs: string, browser: string, context: IE2EContext,
+                timeout: number, headless: boolean, noInstall: boolean) {
         this.workingDir = workingDir;
         this.mainDir = mainDir;
         this.browser = browser;
         this.plugins = plugins;
+        this.specs = specs;
         this.context = context;
         this.timeout = timeout;
         this.headless = headless;
+        this.noInstall = noInstall;
     }
 
     private static safePath(filePath: string): string {
@@ -48,7 +54,11 @@ export class WdioConfigGenerator {
         this.plugins.forEach((plugin) => {
             const e2eFolder = WdioConfigGenerator.pathToE2EFolder(plugin, this.workingDir);
             const mainDir = WdioConfigGenerator.safePath(this.mainDir);
-            const config = new ConfigTemplate(mainDir, e2eFolder, this.browser, this.context.baseUrl, this.timeout, this.headless);
+            const config = new ConfigTemplate(
+                mainDir, e2eFolder,
+                this.specs, this.browser, this.context.baseUrl,
+                this.timeout, this.headless, this.noInstall
+            );
             fs.writeFileSync(path.join(e2eFolder, WdioConfigGenerator.WDIO_CONF_NAME), config.getTemplate(), {encoding: 'utf8'});
         });
     }


### PR DESCRIPTION
Allows to explicitly specify patterns to search for specs files and also to skip the installation step of selenium-standalone which causes the test runs to fail if no network is available.