### PR TITLE
32 Bit Driver for Internet Explorer

### DIFF
--- a/src/commands/e2e/ConfigTemplate.ts
+++ b/src/commands/e2e/ConfigTemplate.ts
@@ -1,3 +1,5 @@
+import {E2E} from './E2E';
+
 export class ConfigTemplate {
     private readonly template: string;
 
@@ -6,8 +8,7 @@ export class ConfigTemplate {
                 timeout: number, headless: boolean, noInstall: boolean) {
         let capabilities = '';
         if (headless) {
-            capabilities = `
-            capabilities: [{
+            capabilities = `[{
                 maxInstances: 1,
                 browserName: '${browser}',
                 'goog:chromeOptions': {
@@ -16,13 +17,37 @@ export class ConfigTemplate {
                         '--disable-gpu'
                     ]
                 }
-            }],`;
+            }]`;
         } else {
-            capabilities = `
-            capabilities: [{
+            capabilities = `[{
                 maxInstances: 1,
                 browserName: '${browser}'
-            }],`;
+            }]`;
+        }
+
+        let ieDriver: string = '';
+        if (browser === E2E.IE) {
+            ieDriver = `
+            seleniumArgs: {
+                baseURL: 'https://selenium-release.storage.googleapis.com',
+                drivers: {
+                    ie: {
+                        version: '3.4.0',
+                        arch: 'ia32',
+                        baseURL: 'https://selenium-release.storage.googleapis.com'
+                    }
+                }
+            },
+            seleniumInstallArgs: {
+                baseURL: 'https://selenium-release.storage.googleapis.com',
+                drivers: {
+                    ie: {
+                        version: '3.4.0',
+                        arch: 'ia32',
+                        baseURL: 'https://selenium-release.storage.googleapis.com'
+                    }
+                }
+            },`;
         }
 
         this.template = `exports.config = {
@@ -43,7 +68,7 @@ export class ConfigTemplate {
             ],
             exclude: [],
             maxInstances: 1,
-            ${capabilities}
+            capabilities: ${capabilities},
             logLevel: 'info',
             bail: 0,
             baseUrl: '${baseUrl}',
@@ -59,6 +84,7 @@ export class ConfigTemplate {
             plugins: {
                 webdriverajax: {}
             },
+            ${ieDriver}
             reporters: ['spec']
         };`;
     }

--- a/src/commands/e2e/E2E.ts
+++ b/src/commands/e2e/E2E.ts
@@ -11,6 +11,9 @@ import {IE2EContext} from './E2EEnvTemplate';
 import {getPathToMainRepo} from '../../util';
 
 export class E2E implements ICommand {
+    public static readonly IE: string = 'internet explorer';
+    public static readonly EDGE: string = 'MicrosoftEdge';
+
     private static readonly PARAMETER_BASE_URL: string = 'baseUrl';
     private static readonly PARAMETER_CONTEXT: string = 'context';
     private static readonly PARAMETER_TENANTID: string = 'tenantId';
@@ -115,7 +118,13 @@ export class E2E implements ICommand {
 
         const browser = params[E2E.PARAMETER_BROWSER];
         if (typeof browser === 'string' && browser.length > 0) {
-            this.browser = browser;
+            if (browser.toLowerCase().includes('ie') || browser.toLowerCase().includes('internet') || browser.toLowerCase().includes('explorer')) {
+                this.browser = E2E.IE;
+            } else if (browser.toLowerCase().includes('edge')) {
+                this.browser = E2E.EDGE;
+            } else {
+                this.browser = browser;
+            }
         } else {
             this.browser = E2E.DEFAULT_BROWSER;
         }
@@ -139,7 +148,7 @@ export class E2E implements ICommand {
             this.noInstall = false;
         }
 
-        if (this.browser.toLowerCase() !== 'chrome') {
+        if (this.browser.toLowerCase() !== 'chrome' && this.headless) {
             this.headless = false;
             console.error(`! Headless disabled - only available for Chrome execution`);
         }


### PR DESCRIPTION
By default selenium-standalone package takes 64-Bit Drivers for Internet Explorer.
This is known to be very slow https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/5116. As suggested in the thread 32-Bit Driver solves the performance issue.

Another workaround could be:
`If you insist that you must run the 64-bit version of IEDriverServer.exe, you have
two possible workarounds. First, you can disable native events by setting the "nativeEvents"
capability to false using whatever mechanism your language binding provides for this.
A more accurate workaround from an input simulation perspective would be to enable
the "requireWindowFocus" capability, though this also has a windows hook dependency,
which may manifest in other ways.`