### PR TITLE
Removed unneccessary Patterns for Release Notes Generation

### DIFF
--- a/src/commands/release-notes/ReleaseNotesMessagesFile.ts
+++ b/src/commands/release-notes/ReleaseNotesMessagesFile.ts
@@ -8,6 +8,7 @@ import {fs} from '../../p/fs';
 import {enforceNewline, makeSingleLine} from '../../util';
 
 type MessageEntryStatus = 'ok' | 'commented' | 'conflict';
+
 interface IReleaseNotesMessageEntry {
     readonly hash: string;
     status: MessageEntryStatus;
@@ -21,9 +22,6 @@ export class ReleaseNotesMessagesFile {
     private static readonly CHANGELOG_DEFAULT_MESSAGE_PATTERN: RegExp = new RegExp(/(^|\n)changelog:[^\S\n]*(([^\n]|\n(?!\n))*)/);
     private static readonly RELEVANCE_PATTERNS: string[] = [
         'merge pull request #\\d+', // GitHub Pull Request
-        '\\bcloses? #\\d+', // GitHub Issues
-        '\\bissue-\\d+', // Intranet / Project Issues
-        '\\bus-\\d+', // Intranet / Project User Stories
         '\\bchangelog\\b' // Explicit changelog marker
     ];
 
@@ -177,11 +175,11 @@ export class ReleaseNotesMessagesFile {
         });
 
         const content = allEntries
-                .map((e) => {
-                    const hash = this.getPrefixForStatus(e.status) + e.hash;
-                    return `${hash}:${e.message}`;
-                })
-                .join('\n') + '\n';
+            .map((e) => {
+                const hash = this.getPrefixForStatus(e.status) + e.hash;
+                return `${hash}:${e.message}`;
+            })
+            .join('\n') + '\n';
         return fs
             .writeFileAsync(this.path, content, 'utf8')
             .then(


### PR DESCRIPTION
As stated in issue #11 for backwards compatibility:
> The messages contained in messages_*.db should be treated as if they came from explicits_*.db

For my point of view they are already treated the same way:

```
for (const c of log) {
            const message = file.getMessage(c.hash) || (explicits && explicits.getMessage(c.hash));
            if (message) {
                changelog.push(`   * ${message}`);
            }
  }
```

e.g:
if I manually add a message of a commit contained within specified range that does not match the pattern to message_en.db the message will appear in CHANGELOG.md
-> backwards compatibility

closes #11