### PR TITLE
Add support for allure reporter

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,7 +112,7 @@ const cli = meow(`
                 'src/main/java' and 'src/test/java'
         
         e2e [--baseUrl <baseUrl>] [--context <context>] [--tenantId <tenantId>] [--e2eToken <token>] [--browser <browser>] [--plugins <plugins>] [--specs <specs>] [--timeout <timeout>] 
-            [--headless] [--noInstall] [--jUnit <?reportsPath>] [--screenshot <?screenshotPath>]
+            [--headless] [--noInstall] [--jUnit <?reportsPath>] [--screenshot <?screenshotPath>] [--allure <?allureOutputPath>]
         
             --baseUrl to configure where to run the tests against (default: 'http://localhost:8083')
             --context to define in which context cplace is running (default: '/intern/tricia/')
@@ -125,7 +125,8 @@ const cli = meow(`
             --headless currently only possible in Chrome and Firefox
             --noInstall will skip the check for new Selenium Drivers (required to run offline, default: false)
             --jUnit will create jUnit reports and allows you to specify the location where the reports are stored (default: './e2eJunitReports')
-            --screenshot will create Screenshots on each failed Test and store them in given Path (default: './e2eScreenshots')
+            --screenshot will create Screenshots on each failed Test and store them in given path (default: './e2eScreenshots')
+            --allure will create Allure Reporter output files and store them in the given path (default: './allure-output')
             
 
     Global options:

--- a/src/commands/e2e/ConfigTemplate.ts
+++ b/src/commands/e2e/ConfigTemplate.ts
@@ -10,7 +10,11 @@ export class ConfigTemplate {
     // tslint:disable-next-line:max-func-body-length
     constructor(mainRepoDir: string, e2eFolder: string,
                 specs: string, browser: string, baseUrl: string, context: IE2EContext,
-                timeout: number, headless: boolean, noInstall: boolean, jUnitReportPath: string, screenShotPath: string, e2eToken: string) {
+                timeout: number, headless: boolean, noInstall: boolean,
+                jUnitReportPath: string,
+                allureOutputPath: string,
+                screenShotPath: string,
+                e2eToken: string) {
         let capabilities: string;
         const tenant: string = context.tenantId.length > 0 ? context.tenantId + '/' : '';
         if (context.context.length === 0 && context.tenantId.length === 0) {
@@ -66,6 +70,7 @@ export class ConfigTemplate {
                 }
             },`;
         }
+
         let junitConfig = '';
         if (jUnitReportPath) {
             junitConfig = `, ['junit', {
@@ -74,6 +79,13 @@ export class ConfigTemplate {
                     function(opts) {
                         return \`e2e.xunit.\${opts.capabilities.browserName}.\${new Date().toISOString().replace(/[:]/g, '-')}.xml\`;
                     }
+                }]`;
+        }
+
+        let allureConfig = '';
+        if (allureOutputPath) {
+            allureConfig = `, ['allure', {
+                    outputDir: '${WdioConfigGenerator.safePath(path.resolve(allureOutputPath))}'
                 }]`;
         }
 
@@ -165,6 +177,7 @@ exports.config = {
     ${ieDriver}
     reporters: ['spec'
     ${junitConfig}
+    ${allureConfig}
     ]
 };`;
     }

--- a/src/commands/e2e/E2E.test.ts
+++ b/src/commands/e2e/E2E.test.ts
@@ -1,0 +1,74 @@
+import {E2E} from './E2E';
+import {withTempDirectory} from '../../test/helpers/directories';
+import * as util from '../../util';
+import {mocked} from 'ts-jest/utils';
+import * as path from 'path';
+import {fs} from '../../p/fs';
+
+jest.mock('../../util');
+
+test('E2E detects Allure Reporter in Dev Dependencies', async () => {
+    await withTempDirectory('e2e-allure', async (dir) => {
+        mocked(util).getPathToMainRepo.mockReturnValue(dir);
+
+        const packageJson = {
+            name: 'cplace',
+            private: true,
+            devDependencies: {
+                '@wdio/allure-reporter': '^5.22.4'
+            }
+        };
+
+        const packageJsonPath = path.join(dir, 'package.json');
+        await fs.writeFileAsync(packageJsonPath, JSON.stringify(packageJson), 'utf8');
+
+        const e2eCommand = new E2E();
+        e2eCommand.prepareAndMayExecute({});
+        expect(e2eCommand.isAllureReporterInstalled()).toBe(true);
+    });
+});
+
+test('E2E detects Allure Reporter in Dependencies', async () => {
+    await withTempDirectory('e2e-allure', async (dir) => {
+        mocked(util).getPathToMainRepo.mockReturnValue(dir);
+
+        const packageJson = {
+            name: 'cplace',
+            private: true,
+            dependencies: {
+                '@wdio/allure-reporter': '^5.22.4'
+            },
+            devDependencies: {
+                'allure-commandline': '1.0.0'
+            }
+        };
+
+        const packageJsonPath = path.join(dir, 'package.json');
+        await fs.writeFileAsync(packageJsonPath, JSON.stringify(packageJson), 'utf8');
+
+        const e2eCommand = new E2E();
+        e2eCommand.prepareAndMayExecute({});
+        expect(e2eCommand.isAllureReporterInstalled()).toBe(true);
+    });
+});
+
+test('E2E detects missing Allure Reporter', async () => {
+    await withTempDirectory('e2e-allure', async (dir) => {
+        mocked(util).getPathToMainRepo.mockReturnValue(dir);
+
+        const packageJson = {
+            name: 'cplace',
+            private: true,
+            dependencies: {
+                '@wdio/nothing-allure': '0.0.0'
+            }
+        };
+
+        const packageJsonPath = path.join(dir, 'package.json');
+        await fs.writeFileAsync(packageJsonPath, JSON.stringify(packageJson), 'utf8');
+
+        const e2eCommand = new E2E();
+        e2eCommand.prepareAndMayExecute({});
+        expect(e2eCommand.isAllureReporterInstalled()).toBe(false);
+    });
+});

--- a/src/commands/e2e/E2E.ts
+++ b/src/commands/e2e/E2E.ts
@@ -27,6 +27,7 @@ export class E2E implements ICommand {
     private static readonly PARAMETER_HEADLESS: string = 'headless';
     private static readonly PARAMETER_NO_INSTALL: string = 'noInstall';
     private static readonly PARAMETER_JUNIT: string = 'jUnit';
+    private static readonly PARAMETER_ALLURE: string = 'allure';
     private static readonly PARAMETER_SCREENSHOT: string = 'screenshot';
 
     // Default
@@ -35,6 +36,7 @@ export class E2E implements ICommand {
     private static readonly DEFAULT_BROWSER: string = 'chrome';
     private static readonly DEFAULT_TIMEOUT: number = 30000;
     private static readonly DEFAULT_JUNITREPORTPATH: string = './e2eJunitReports';
+    private static readonly DEFAULT_ALLUREOUTPUTPATH: string = './allure-output';
     private static readonly DEFAULT_SCREEENSHOTPATH: string = './e2eScreenshots';
 
     private workingDir: string;
@@ -52,6 +54,7 @@ export class E2E implements ICommand {
     private headless: boolean;
     private noInstall: boolean;
     private jUnitReportPath: string;
+    private allureOutputPath: string;
     private screenshotPath: string;
 
     private testRunner: TestRunner | null = null;
@@ -162,6 +165,13 @@ export class E2E implements ICommand {
             this.jUnitReportPath = E2E.DEFAULT_JUNITREPORTPATH;
         }
 
+        const allure = params[E2E.PARAMETER_ALLURE] || params[E2E.PARAMETER_ALLURE.toLowerCase()];
+        if (typeof allure === 'string' && allure.length > 0) {
+            this.allureOutputPath = allure;
+        } else if (typeof allure === 'boolean') {
+            this.allureOutputPath = E2E.DEFAULT_ALLUREOUTPUTPATH;
+        }
+
         const screenshot = params[E2E.PARAMETER_SCREENSHOT];
         if (typeof screenshot === 'string' && screenshot.length > 0) {
             this.screenshotPath = screenshot;
@@ -205,7 +215,10 @@ export class E2E implements ICommand {
         const wdioGenerator = new WdioConfigGenerator(
             this.workingDir, this.mainRepoDir,
             this.pluginsToBeTested, this.specs, this.browser, context,
-            this.timeout, this.headless, this.noInstall, this.jUnitReportPath, this.screenshotPath
+            this.timeout, this.headless, this.noInstall,
+            this.jUnitReportPath,
+            this.allureOutputPath,
+            this.screenshotPath
         );
 
         console.log('Generating WDIO configuration files...');

--- a/src/commands/e2e/E2E.ts
+++ b/src/commands/e2e/E2E.ts
@@ -165,7 +165,7 @@ export class E2E implements ICommand {
             this.jUnitReportPath = E2E.DEFAULT_JUNITREPORTPATH;
         }
 
-        const allure = params[E2E.PARAMETER_ALLURE] || params[E2E.PARAMETER_ALLURE.toLowerCase()];
+        const allure = params[E2E.PARAMETER_ALLURE];
         if (typeof allure === 'string' && allure.length > 0) {
             this.allureOutputPath = allure;
         } else if (typeof allure === 'boolean') {

--- a/src/commands/e2e/WdioConfigGenerator.ts
+++ b/src/commands/e2e/WdioConfigGenerator.ts
@@ -17,11 +17,13 @@ export class WdioConfigGenerator {
     private readonly headless: boolean;
     private readonly noInstall: boolean;
     private readonly jUnitReportPath: string;
+    private readonly allureOutputPath: string;
     private readonly screenshotPath: string;
 
     constructor(workingDir: string, mainDir: string,
                 plugins: string[], specs: string, browser: string, context: IE2EContext,
-                timeout: number, headless: boolean, noInstall: boolean, jUnitReportPath: string, screenshotPath: string) {
+                timeout: number, headless: boolean, noInstall: boolean,
+                jUnitReportPath: string, allureOutputPath: string, screenshotPath: string) {
         this.workingDir = workingDir;
         this.mainDir = mainDir;
         this.browser = browser;
@@ -32,6 +34,7 @@ export class WdioConfigGenerator {
         this.headless = headless;
         this.noInstall = noInstall;
         this.jUnitReportPath = jUnitReportPath;
+        this.allureOutputPath = allureOutputPath;
         this.screenshotPath = screenshotPath;
     }
 
@@ -61,7 +64,11 @@ export class WdioConfigGenerator {
             const config = new ConfigTemplate(
                 mainDir, e2eFolder,
                 this.specs, this.browser, this.context.baseUrl, this.context,
-                this.timeout, this.headless, this.noInstall, this.jUnitReportPath, this.screenshotPath, this.context.e2eToken
+                this.timeout, this.headless, this.noInstall,
+                this.jUnitReportPath,
+                this.allureOutputPath,
+                this.screenshotPath,
+                this.context.e2eToken
             );
             fs.writeFileSync(path.join(e2eFolder, WdioConfigGenerator.WDIO_CONF_NAME), config.getTemplate(), {encoding: 'utf8'});
         });


### PR DESCRIPTION
Adds a new flag `--allure` to the `e2e` command which allows generation of Allure specific output for easy reporting.

Closes #47 