### PR TITLE
set default timeout from 30000ms to 60000ms

### DIFF
--- a/src/commands/e2e/E2E.ts
+++ b/src/commands/e2e/E2E.ts
@@ -34,7 +34,7 @@ export class E2E implements ICommand {
     private static readonly DEFAULT_BASE_URL: string = 'http://localhost:8083';
     private static readonly DEFAULT_CONTEXT: string = '/intern/tricia/';
     private static readonly DEFAULT_BROWSER: string = 'chrome';
-    private static readonly DEFAULT_TIMEOUT: number = 30000;
+    private static readonly DEFAULT_TIMEOUT: number = 60000;
     private static readonly DEFAULT_JUNITREPORTPATH: string = './e2eJunitReports';
     private static readonly DEFAULT_ALLUREOUTPUTPATH: string = './allure-output';
     private static readonly DEFAULT_SCREEENSHOTPATH: string = './e2eScreenshots';


### PR DESCRIPTION
Resolves [ISSUE-4497 set default timeout to 60000ms](https://base.cplace.io/pages/d4wlrz3eqvpsvj0z8mr0ifnrc/ISSUE-4497-set-mocha-timeout-to-60000ms#id_ryv8bgmhbp5kptlna9mpurvyu=Layout_AppsTeam_Issue_intro)

`changelog: : [ISSUE-4497, PR cplace--npm-tools]`
