### PR TITLE
settle all parallel promises instead of bailing out early

### DIFF
--- a/src/commands/refactor/RefactorTestSourcesCommand.ts
+++ b/src/commands/refactor/RefactorTestSourcesCommand.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import {Global} from '../../Global';
 import * as rimraf from 'rimraf';
+import {promiseAllSettledParallel} from '../../promiseAllSettled';
 
 /**
  * This command will refactor an "old" plugin structure using only `src/classes/...` or `src/java/...`
@@ -208,7 +209,7 @@ export class RefactorTestSourcesCommand implements IRefactoringCommand {
             });
         });
 
-        await Promise.all([sourcePromise, buildPromise]);
+        await promiseAllSettledParallel([sourcePromise, buildPromise]);
     }
 
     private async moveDirectory(fromPath: string, toPath: string): Promise<void> {

--- a/src/commands/repos/CloneRepos.ts
+++ b/src/commands/repos/CloneRepos.ts
@@ -7,6 +7,7 @@ import {fs} from '../../p/fs';
 import {AbstractReposCommand} from './AbstractReposCommand';
 import {Repository} from '../../git';
 import {Global} from '../../Global';
+import {promiseAllSettledParallel} from '../../promiseAllSettled';
 
 export class CloneRepos extends AbstractReposCommand {
 
@@ -21,8 +22,7 @@ export class CloneRepos extends AbstractReposCommand {
                 return Repository.clone(toPath, repoProperties.url, repoProperties.branch);
             });
 
-        return Promise
-            .all(promises)
+        return promiseAllSettledParallel(promises)
             .then(
                 () => {
                     // pass

--- a/src/commands/repos/add-dependency/IdeaDependencyManagement.ts
+++ b/src/commands/repos/add-dependency/IdeaDependencyManagement.ts
@@ -5,6 +5,7 @@ import {Global} from '../../../Global';
 import * as fs from 'fs';
 import * as xml2js from 'xml2js';
 import {ImlParser} from '../ImlParser';
+import {promiseAllSettledParallel} from '../../../promiseAllSettled';
 
 export class IdeaDependencyManagement extends DependencyManagement {
 
@@ -104,7 +105,7 @@ export class IdeaDependencyManagement extends DependencyManagement {
                          .then((moduleRoot: IModulesXmlRoot) => ({repoName, moduleRoot}))
             );
 
-        return Promise.all(readModules)
+        return promiseAllSettledParallel(readModules)
             .then((repoAndModuleRoots) => repoAndModuleRoots
                 .map(({repoName, moduleRoot}) => {
                     Global.isVerbose() && console.log(moduleRoot.project.component[0].modules[0]);
@@ -142,7 +143,7 @@ export class IdeaDependencyManagement extends DependencyManagement {
         try {
             const filepath = moduleEntry.filepath.replace('$PROJECT_DIR$/', '');
             const imlParser = new ImlParser(path.join(this.repositoryDir, filepath));
-            const result = await Promise.all(imlParser.getReferencedModules().map((moduleName) => this.findPluginInRepos(moduleName)));
+            const result = await promiseAllSettledParallel(imlParser.getReferencedModules().map((moduleName) => this.findPluginInRepos(moduleName)));
             return result.map(
                 (entry) => this.adjustPathsAndGroup(entry.repoName, entry.moduleEntry)
             );

--- a/src/commands/visualize/VisualizeCommand.ts
+++ b/src/commands/visualize/VisualizeCommand.ts
@@ -8,6 +8,7 @@ import {Repository} from '../../git';
 import * as os from 'os';
 import {fs} from '../../p/fs';
 import {exec} from 'child_process';
+import {promiseAllSettledParallel} from '../../promiseAllSettled';
 
 export class VisualizeCommand implements ICommand {
 
@@ -77,7 +78,7 @@ export class VisualizeCommand implements ICommand {
                             }
                         });
                 });
-                return Promise.all(branchPromises).then(() => {
+                return promiseAllSettledParallel(branchPromises).then(() => {
                     console.log('Reducing dependencies...');
                     this.reduce();
                 }).then(() => {

--- a/src/promiseAllSettled.ts
+++ b/src/promiseAllSettled.ts
@@ -131,3 +131,16 @@ class PromiseAllSettled<K, T> {
 export function promiseAllSettled<K, T>(options: { keys: K[], promiseFactory: ((key: K) => Promise<T>), sequential: boolean }): Promise<T[]> {
     return new PromiseAllSettled(options.keys, options.promiseFactory, options.sequential).run();
 }
+
+/**
+ * Awaits all provided promises, as if by calling {@link #promiseAllSettled} with
+ * keys being the keys of the array,
+ * promiseFactory returning the promise for each key,
+ * and sequential being false.
+ * @param promises An array of promises.
+ * @return an array of results, if all promises resolved
+ * @throws an Error containing details about all rejected promises, if any promise was rejected
+ */
+export function promiseAllSettledParallel<T>(promises: Array<Promise<T>>): Promise<T[]> {
+    return promiseAllSettled({keys: [...promises.keys()], promiseFactory: (key) => promises[key], sequential: false});
+}

--- a/src/test/helpers/gradle.ts
+++ b/src/test/helpers/gradle.ts
@@ -1,6 +1,7 @@
 import {withTempDirectory} from './directories';
 import * as path from 'path';
 import {fs} from '../../p/fs';
+import {promiseAllSettledParallel} from '../../promiseAllSettled';
 
 export function withTempGradleBuild(func: (directory: string) => Promise<void>,
                                     buildGradleContent?: () => string,
@@ -19,7 +20,7 @@ export async function createGradleBuild(gradleDirectory: string,
                                         settingsGradleContent?: () => string): Promise<void> {
     const buildGradle = path.join(gradleDirectory, 'build.gradle');
     const settingsGradle = path.join(gradleDirectory, 'settings.gradle');
-    await Promise.all(
+    await promiseAllSettledParallel(
         [
             fs.writeFileAsync(buildGradle, buildGradleContent ? buildGradleContent() : '', 'utf-8'),
             fs.writeFileAsync(settingsGradle, settingsGradleContent ? settingsGradleContent() : '', 'utf-8')

--- a/src/test/helpers/repositories.ts
+++ b/src/test/helpers/repositories.ts
@@ -3,6 +3,7 @@ import {withTempDirectory} from './directories';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as child_process from 'child_process';
+import {promiseAllSettledParallel} from '../../promiseAllSettled';
 
 export function withRepositories(repos: IReposDescriptor,
                                  func: (rootDir: string) => Promise<void>): Promise<void> {
@@ -16,7 +17,6 @@ export function withRepositories(repos: IReposDescriptor,
 }
 
 function createRepositories(repos: IReposDescriptor, rootDir: string): Promise<void[]> {
-    // tslint:disable-next-line:prefer-array-literal
     const promises: Array<Promise<void>> = Object.keys(repos).map((repoName) => {
         const pathToRepo = path.join(rootDir, repoName);
         const descriptor = repos[repoName];
@@ -44,5 +44,5 @@ function createRepositories(repos: IReposDescriptor, rootDir: string): Promise<v
             );
         });
     });
-    return Promise.all(promises);
+    return promiseAllSettledParallel(promises);
 }


### PR DESCRIPTION
When `Promise.all` sees a rejection, it rejects immediately. That rejection bubbles all the way up to `cli.ts`, where `System.exit` is called to abort the process. This has already led to inconsistencies in the working copy, see #50.
The proposed solution is to await all parallel promises before rejecting, thereby finishing all other parallel work before aborting the process. An added benefit is that all concurrent failures are reported instead of just the first one.