### PR TITLE
Command repos -u allows pulling from non-tracking branch

### DIFF
--- a/src/commands/repos/UpdateRepos.ts
+++ b/src/commands/repos/UpdateRepos.ts
@@ -75,6 +75,8 @@ export class UpdateRepos extends AbstractReposCommand {
 
         const status = await repo.status();
         await this.checkRepoClean(repo, status);
+        // check existence of our target branch
+        await this.getTargetBranch(repo, repoProperties);
 
         Global.isVerbose() && console.log('prepare repo', repoName, 'OK');
     }
@@ -161,6 +163,11 @@ export class UpdateRepos extends AbstractReposCommand {
             }
         } else {
             targetBranch = tag;
+        }
+        try {
+            await repo.commitExists(targetBranch);
+        } catch (e) {
+            return Promise.reject(`Cannot update repo ${repo.repoName}: Missing branch/commit/tag ${targetBranch}!`);
         }
         return targetBranch;
     }

--- a/src/commands/repos/UpdateRepos.ts
+++ b/src/commands/repos/UpdateRepos.ts
@@ -95,34 +95,12 @@ export class UpdateRepos extends AbstractReposCommand {
         const wasGradleBuild = new GradleBuild(pathToRepo).containsGradleBuild();
 
         const repo = new Repository(pathToRepo);
-
-        let targetCommit: string;
-        if (branch) {
-            if (commit) {
-                targetCommit = commit;
-            } else if (this.resetToRemote) {
-                targetCommit = `origin/${branch}`;
-            } else if (this.noFetch) {
-                let branchExists: boolean;
-                try {
-                    await repo.commitExists(branch);
-                    branchExists = true;
-                } catch (e) {
-                    branchExists = false;
-                }
-                targetCommit = branchExists ? branch : `origin/${branch}`;
-            } else {
-                // we did fetch, so the current remote branch is very likely the same as the one we may pull later
-                targetCommit = `origin/${branch}`;
-            }
-        } else {
-            targetCommit = tag;
-        }
+        const targetBranch = await this.getTargetBranch(repo, repoProperties);
 
         const startingBranchHasCheckedInNodeModules = await repo.checkRepoHasPathInBranch({branch: 'HEAD', pathname: AbstractReposCommand.NODE_MODULES});
         Global.isVerbose() && console.log(repoName, 'current branch has ', AbstractReposCommand.NODE_MODULES, 'checked in:', startingBranchHasCheckedInNodeModules);
-        const targetBranchHasCheckedInNodeModules = await repo.checkRepoHasPathInBranch({branch: targetCommit, pathname: AbstractReposCommand.NODE_MODULES});
-        Global.isVerbose() && console.log(repoName, 'target branch ', targetCommit, ' has ', AbstractReposCommand.NODE_MODULES, 'checked in:', targetBranchHasCheckedInNodeModules);
+        const targetBranchHasCheckedInNodeModules = await repo.checkRepoHasPathInBranch({branch: targetBranch, pathname: AbstractReposCommand.NODE_MODULES});
+        Global.isVerbose() && console.log(repoName, 'target branch ', targetBranch, ' has ', AbstractReposCommand.NODE_MODULES, 'checked in:', targetBranchHasCheckedInNodeModules);
 
         if (!startingBranchHasCheckedInNodeModules && targetBranchHasCheckedInNodeModules) {
             console.log(`[${repoName}]: Removing untracked ${AbstractReposCommand.NODE_MODULES} folder because it is checked in in the target branch.\n` +
@@ -159,5 +137,31 @@ export class UpdateRepos extends AbstractReposCommand {
         }
 
         Global.isVerbose() && console.log('successfully updated', repoName);
+    }
+
+    private async getTargetBranch(repo: Repository, {branch, commit, tag}: { branch: string, commit?: string, tag?: string }): Promise<string> {
+        let targetBranch: string;
+        if (branch) {
+            if (commit) {
+                targetBranch = commit;
+            } else if (this.resetToRemote) {
+                targetBranch = `origin/${branch}`;
+            } else if (this.noFetch) {
+                let branchExists: boolean;
+                try {
+                    await repo.commitExists(branch);
+                    branchExists = true;
+                } catch (e) {
+                    branchExists = false;
+                }
+                targetBranch = branchExists ? branch : `origin/${branch}`;
+            } else {
+                // we did fetch, so the current remote branch is very likely the same as the one we may pull later
+                targetBranch = `origin/${branch}`;
+            }
+        } else {
+            targetBranch = tag;
+        }
+        return targetBranch;
     }
 }


### PR DESCRIPTION
Command `repos -u` is unable to update a local branch to the corresponding remote branch if the local branch is not tracking the remote - calling `git pull` fails.
IntelliJ IDEA has no problem with that, and just pulls from the corresponding `origin` branch if it exists.
Similarly, we should fall back to pulling from the corresponding `origin` branch for local branches without configured upstream branch. If no corresponding remote branch exists, we still fail the update for the affected repo (all other repos are still updated).

This PR also rejects the update for all repos if any of the parent repos is missing the target branch (after `fetch`).

`changelog: Command repos -u allows pulling from non-tracking branch [PR cplace-npm-tools#61]`