### PR TITLE
Setup workflow to publish to npm

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
       - name: Setup GIT for testing
         run: git config --global user.email "cplace-npm-tools@cplace.io" && git config --global user.name "cplace-npm-tools GitHub Action"
       - name: Install modules

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,21 @@
+name: NPM Release
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    name: Publish package to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: NPM Install
+        run: npm install
+      - name: NPM Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ To execute the available unit tests run:
 npm run test
 ```
 
-To publish a new version of `cplace-cli` use the great `np` tool. Install it globally with `npm install -g np` and then run `np --help` to see your options.
+## Publishing a new version
 
-> **You must have the appropriate right to publish to the NPM registry!**
+To publish a new version on the NPM registry take the following steps:
+
+1. Manually bump the version number in `package.json` as desired (major / minor / patch).
+2. Push the update to GitHub.
+3. Create a new Release on GitHub:
+   1. Create _a new tag_ matching the version you want to publish, e.g. `v0.20.3`.
+   2. Put in the proper release notes as description of the Release.
+4. On creating the Release (_not as a draft_) the GitHub workflow will run and publish the package to NPM automatically.


### PR DESCRIPTION
This adds a workflow to automatically publish a new version on NPM when a release is created on GitHub.