### PR TITLE
PFM-ISSUE-5421 Screenshots no longer saved in cplace cli e2e

### DIFF
--- a/src/commands/e2e/WdioConfigGenerator.ts
+++ b/src/commands/e2e/WdioConfigGenerator.ts
@@ -48,8 +48,7 @@ export class WdioConfigGenerator {
     public generateWdioConfig(): void {
         this.plugins.forEach((plugin) => {
             const e2eFolder = WdioConfigGenerator.pathToE2EFolder(plugin, this.workingDir);
-            const mainDir = WdioConfigGenerator.safePath(this.mainDir);
-            const config = this.getWdioTemplate(mainDir, e2eFolder);
+            const config = this.getWdioTemplate(e2eFolder);
             fs.writeFileSync(
                 path.join(e2eFolder, WdioConfigGenerator.WDIO_CONF_NAME),
                 config.getTemplate(),
@@ -58,9 +57,9 @@ export class WdioConfigGenerator {
         });
     }
 
-    private getWdioTemplate(mainDir: string, e2eFolder: string): WdioConfigTemplate {
+    private getWdioTemplate(e2eFolder: string): WdioConfigTemplate {
         return new WdioConfigTemplate(
-            mainDir, e2eFolder,
+            WdioConfigGenerator.safePath(this.mainDir), WdioConfigGenerator.safePath(this.workingDir), e2eFolder,
             this.specs, this.browser, this.context.baseUrl, this.context,
             this.timeout, this.headless, this.noInstall,
             this.jUnitReportPath,

--- a/src/commands/e2e/WdioConfigTemplate.ts
+++ b/src/commands/e2e/WdioConfigTemplate.ts
@@ -10,6 +10,7 @@ export class WdioConfigTemplate {
     // tslint:disable-next-line:max-func-body-length
     constructor(
         protected readonly mainRepoDir: string,
+        protected readonly workingDir: string,
         protected readonly e2eFolder: string,
         protected readonly specs: string,
         protected readonly browser: string,
@@ -227,7 +228,7 @@ exports.config = {
 
     protected getScreenshotConfig(): string {
         return `if (!test.passed) {
-            let screenshotDir = '${WdioConfigGenerator.safePath(path.join(this.screenShotPath))}';
+            let screenshotDir = '${WdioConfigGenerator.safePath(path.join(this.workingDir, this.screenShotPath))}';
             screenshotDir = path.join(screenshotDir, test.parent.replace(/[^a-z0-9]/gi, '_').toLowerCase())
 
             if (!fs.existsSync(screenshotDir)) {


### PR DESCRIPTION
[PFM-ISSUE-5421](https://base.cplace.io/pages/6i6fv6epflxof9znln6d4rnn0/PFM-ISSUE-5421-Screenshots-no-longer-saved-in-cplace-cli-e2e)

The directory where the process of the testrunner is started was changed with PR #65  . This only affects screenshots in case tests are started in a project other than cplace main.
In that case screenshots are saved to cplace main folder instead of the project that is being tested. 
