### PR TITLE
PFM-ISSUE-6711 - Add repository description support for parent-repos.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Document Control / Repository Information
-Item | Value 
+
+Item | Value
 --- | ---
-Owner |	Christian Kaltenbach, Philip Stöhrer, Stefan Stadler
-Team |	none yet
-Project  | none
-Parent |	none
-Developed by |	collaboration Factory AG
-Description |	Unser Kommandozeilen-Werkzeug um mit cplace Code zu arbeiten.
+Owner | Christian Kaltenbach, Philip Stöhrer, Stefan Stadler
+Team | none yet
+Project | none
+Parent | none
+Developed by | collaboration Factory AG
+Description | Our commandline utility to work with cplace code
 
 # cplace CLI tools
 
@@ -17,15 +18,19 @@ This package provides some CLI tools for working with cplace code.
 ## Usage
 
 To install `cplace-cli` run the following command:
+
 ```bash
 npm install -g @cplace/cli
 ```
 
 After installation you can just execute:
+
 ```bash
 cplace-cli --help
 ```
+
 to get the available commands and help:
+
 ```text
 $  cplace-cli --help
 
@@ -172,20 +177,25 @@ $  cplace-cli --help
 ## Development
 
 Before you can work with the repository, you need to install node modules once:
+
 ```bash
 npm install
 ```
 
 Typescript is compiled and linted by running:
+
 ```bash
 npm run dev
 ```
+
 This will execute both tslint (`npm run dev:lint`) as well as run the Typescript compiler (`npm run dev:tsc`).
 
 To test your local changes with `cplace-cli` on the command line you have to `link` your local npm package by running:
+
 ```bash
 npm link
 ```
+
 This will first recompile the Typescript sources and do the linting before setting up and linking the binary executable.
 When `npm link` is completed, you can just use `cplace-cli` as usual to test it out.
 When the installation failed because `cplace-cli` was already installed, you can either remove it by running `npm r -g @cplace/cli`, or run `npm link --force`.
@@ -193,6 +203,7 @@ When the installation failed because `cplace-cli` was already installed, you can
 > Remember to clean your local linked package after testing by running `npm r -g @cplace/cli` to remove it and do a regular install again (`npm i -g @cplace/cli`).
 
 To execute the available unit tests run:
+
 ```bash
 npm run test
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8310,9 +8310,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/cli",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/cli",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "description": "",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/commands/repos/WriteRepos.ts
+++ b/src/commands/repos/WriteRepos.ts
@@ -53,7 +53,8 @@ export class WriteRepos extends AbstractReposCommand {
                 const current = this.parentRepos[repo.repoName];
                 const result: IRepoStatus = {
                     url: current.url,
-                    branch: status.current
+                    branch: status.current,
+                    description: current.description ? current.description : repo.repoName
                 };
                 if (this.freeze || current.commit) {
                     result.commit = commit;

--- a/src/commands/repos/models.ts
+++ b/src/commands/repos/models.ts
@@ -11,6 +11,7 @@ export interface IRepoStatus {
     branch: string;
     tag?: string;
     commit?: string;
+    description?: string;
 }
 
 export interface IModulesXmlRoot {


### PR DESCRIPTION
Added `description` field to parent-repos.json. By default it will use the repo name (by that, developers will directly notice this new field).  This field will be used for human-readable release notes (delivered to customer).

For background, see [Slack discussion](https://collaborationfactory.slack.com/archives/CSGV0V9HN/p1616398418011400)