### PR TITLE
PFM-ISSUE-12072: cplace-cli: fix using https when parent-repos.json is configured for ssh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/cli",
-  "version": "0.19.21",
+  "version": "0.19.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/cli",
-  "version": "0.19.21",
+  "version": "0.19.22",
   "description": "cplace cli tools",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/commands/repos/CloneRepos.ts
+++ b/src/commands/repos/CloneRepos.ts
@@ -29,7 +29,7 @@ export class CloneRepos extends AbstractReposCommand {
 
     private handleRepo(toPath: string, repoName: string, repoProperties: IRepoStatus, depth: number): Promise<void> {
         if (!repoProperties.tag && !repoProperties.useSnapshot) {
-            return Repository.getLatestTagOfReleaseBranch(repoName, repoProperties)
+            return Repository.getLatestTagOfReleaseBranch(repoName, repoProperties, this.rootDir)
                 .then((latestTag) => {
                     repoProperties.latestTagForRelease = latestTag;
                     return Repository.clone(toPath, repoName, repoProperties, depth);

--- a/src/commands/repos/CloneRepos.ts
+++ b/src/commands/repos/CloneRepos.ts
@@ -15,32 +15,32 @@ export class CloneRepos extends AbstractReposCommand {
     public execute(): Promise<void> {
         const promises = Object
             .keys(this.parentRepos)
-            .filter((repoName) => this.checkRepoMissing(this.rootDir, repoName))
+            .filter((repoName) => this.checkRepoMissing(repoName, this.rootDir))
             .map((repoName) => {
                 Global.isVerbose() && console.log(`[${repoName}]:`, 'starting to clone repository');
                 const repoProperties = this.parentRepos[repoName];
                 const toPath = path.resolve(this.rootDir, '..', repoName);
-                return this.handleRepo(toPath, repoName, repoProperties, this.depth);
+                return this.handleRepo(repoName, repoProperties, toPath, this.depth);
             });
 
         return promiseAllSettledParallel(promises)
             .catch((err) => Promise.reject(`[CloneRepos]: failed to clone repos: ${err}`));
     }
 
-    private handleRepo(toPath: string, repoName: string, repoProperties: IRepoStatus, depth: number): Promise<void> {
+    private handleRepo(repoName: string, repoProperties: IRepoStatus, toPath: string, depth: number): Promise<void> {
         if (!repoProperties.tag && !repoProperties.useSnapshot) {
             return Repository.getLatestTagOfReleaseBranch(repoName, repoProperties, this.rootDir)
                 .then((latestTag) => {
                     repoProperties.latestTagForRelease = latestTag;
-                    return Repository.clone(toPath, repoName, repoProperties, depth);
+                    return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth);
                 })
                 .catch((err) => Promise.reject(`[${repoName}]: failed to handle repo due to\n${err}`));
         } else {
-            return Repository.clone(toPath, repoName, repoProperties, depth);
+            return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth);
         }
     }
 
-    private checkRepoMissing(rootDir: string, repoName: string): boolean {
+    private checkRepoMissing(repoName: string, rootDir: string ): boolean {
         const pathToRepo = path.resolve(rootDir, '..', repoName);
         const exists = fs.existsSync(pathToRepo);
         Global.isVerbose() && console.log(`[${repoName}]:`, 'repository already exists:', exists);

--- a/src/commands/repos/UpdateRepos.ts
+++ b/src/commands/repos/UpdateRepos.ts
@@ -69,7 +69,7 @@ export class UpdateRepos extends AbstractReposCommand {
             return Promise.reject(`[${repoName}]: No branch or tag given in parent-repos.json for repo ${repoName}`);
         }
         if (!repoProperties.tag && !repoProperties.useSnapshot) {
-            repoProperties.latestTagForRelease = await Repository.getLatestTagOfReleaseBranch(repoName, repoProperties);
+            repoProperties.latestTagForRelease = await Repository.getLatestTagOfReleaseBranch(repoName, repoProperties, this.rootDir);
         }
 
         const pathToRepo = path.join(this.rootDir, '..', repoName);

--- a/src/commands/repos/WriteRepos.ts
+++ b/src/commands/repos/WriteRepos.ts
@@ -72,7 +72,7 @@ export class WriteRepos extends AbstractReposCommand {
                 resolve({repoName, status});
             });
         } else if (this.useTags) {
-            return Repository.getActiveTagOfReleaseBranch(repoName, this.parentRepos[repoName])
+            return Repository.getActiveTagOfReleaseBranch(repoName, this.parentRepos[repoName], this.rootDir)
                 .then((activeTag) => {
                     if (activeTag) {
                         const current = this.parentRepos[repoName];

--- a/test/git/Repository.test.ts
+++ b/test/git/Repository.test.ts
@@ -14,6 +14,7 @@ async function remoteSetUrl(rootDir: string, remoteUri: string): Promise<void> {
         }
     });
 }
+
 describe('testing the repository helpers', () => {
 
     test('test that the correct remote url is returned by getLocalOriginUrl', async () => {
@@ -55,6 +56,27 @@ describe('testing the repository helpers', () => {
             .evaluateWithRemoteAndLocalRepos(testGetRemoteOriginUrl, assertThatAValidRemoteIsGiven);
     });
 
+    test('test getRemoteOriginUrl, local: https, remote: https -> https', async () => {
+        const testGetRemoteOriginUrl = async (rootDir: string): Promise<string> => {
+            // rewrite the remote url to git via https
+            await remoteSetUrl(rootDir, GIT_VIA_HTTPS_URI);
+
+            // assume the url in the parent repos would be for git via ssh
+            const result = await Repository.getRemoteOriginUrl(ROOT_REPO, GIT_VIA_HTTPS_URI, rootDir);
+            console.log(result);
+            return result;
+        };
+
+        const assertThatAValidRemoteIsGiven = async (localOriginUrl: string): Promise<void> => {
+            expect(localOriginUrl).toBeDefined();
+            expect(localOriginUrl.trim()).toEqual(GIT_VIA_HTTPS_URI);
+        };
+
+        await testWith(basicTestSetupData)
+            .withBranchUnderTest('release/22.2')
+            .evaluateWithRemoteAndLocalRepos(testGetRemoteOriginUrl, assertThatAValidRemoteIsGiven);
+    });
+
     test('test getRemoteOriginUrl, local: https, remote: ssh -> https', async () => {
         const testGetRemoteOriginUrl = async (rootDir: string): Promise<string> => {
             // rewrite the remote url to git via https
@@ -76,7 +98,7 @@ describe('testing the repository helpers', () => {
             .evaluateWithRemoteAndLocalRepos(testGetRemoteOriginUrl, assertThatAValidRemoteIsGiven);
     });
 
-    test('test getRemoteOriginUrl, local: ssh, remote: https -> https', async () => {
+    test('test getRemoteOriginUrl, local: ssh, remote: https -> ssh', async () => {
         const testGetRemoteOriginUrl = async (rootDir: string): Promise<string> => {
             // rewrite the remote url to git via ssh
             await remoteSetUrl(rootDir, GIT_VIA_SSH_URI);
@@ -89,7 +111,7 @@ describe('testing the repository helpers', () => {
 
         const assertThatAValidRemoteIsGiven = async (localOriginUrl: string): Promise<void> => {
             expect(localOriginUrl).toBeDefined();
-            expect(localOriginUrl.trim()).toEqual(GIT_VIA_HTTPS_URI);
+            expect(localOriginUrl.trim()).toEqual(GIT_VIA_SSH_URI);
         };
 
         await testWith(basicTestSetupData)

--- a/test/git/Repository.test.ts
+++ b/test/git/Repository.test.ts
@@ -2,6 +2,18 @@ import {basicTestSetupData, ROOT_REPO, testWith} from '../helpers/remoteReposito
 import {Repository} from '../../src/git';
 import * as simpleGit from 'simple-git';
 
+const GIT_VIA_SSH_URI = `git@github.com:collaborationFactory/${ROOT_REPO}.git`;
+const GIT_VIA_HTTPS_URI = `https://github.com/collaborationFactory/${ROOT_REPO}.git`;
+
+async function remoteSetUrl(rootDir: string, remoteUri: string): Promise<void> {
+    await simpleGit(rootDir).remote(['set-url', 'origin', remoteUri], (err, execResult: string) => {
+        if (err) {
+            throw err;
+        } else {
+            console.log('remote set-utl result:', execResult);
+        }
+    });
+}
 describe('testing the repository helpers', () => {
 
     test('test that the correct remote url is returned by getLocalOriginUrl', async () => {
@@ -13,7 +25,7 @@ describe('testing the repository helpers', () => {
 
         const assertThatAValidRemoteIsGiven = async (localOriginUrl: string): Promise<void> => {
             expect(localOriginUrl).toBeDefined();
-            // The path would look like this on linux/osx:  /var/folders/jt/bcd1vz211hq913bbvmsvqd7h0000gn/T/1679059235280-cplace-cli-test-freeze-parent-repos/remote/rootRepo.git
+            // The path would look like this on linux/osx: /var/folders/jt/bcd1vz211hq913bbvmsvqd7h0000gn/T/1679059235280-cplace-cli-test-freeze-parent-repos/remote/rootRepo.git
             expect(/^.*\/remote\/rootRepo.git$/.test(localOriginUrl.trim())).toBeTruthy();
         };
 
@@ -22,25 +34,20 @@ describe('testing the repository helpers', () => {
             .evaluateWithRemoteAndLocalRepos(testGetLocalOriginUrl, assertThatAValidRemoteIsGiven);
     });
 
-    test('test that getRemoteOriginUrl stays with git via ssh if the local repo has ssh configured for git', async () => {
+    test('test getRemoteOriginUrl, local: ssh, remote: ssh -> ssh', async () => {
         const testGetRemoteOriginUrl = async (rootDir: string): Promise<string> => {
             // rewrite the remote url to git via https
-            await simpleGit(rootDir).remote(['set-url', 'origin', 'git@github.com:collaborationFactory/rootRepo.git'], (err, execResult: string) => {
-                if (err) {
-                    throw err;
-                } else {
-                    console.log('remote set-utl result:', execResult);
-                }
-            });
+            await remoteSetUrl(rootDir, GIT_VIA_SSH_URI);
+
             // assume the url in the parent repos would be for git via ssh
-            const result = await Repository.getRemoteOriginUrl(ROOT_REPO, `git@github.com:collaborationFactory/${ROOT_REPO}.git`, rootDir);
+            const result = await Repository.getRemoteOriginUrl(ROOT_REPO, GIT_VIA_SSH_URI, rootDir);
             console.log(result);
             return result;
         };
 
         const assertThatAValidRemoteIsGiven = async (localOriginUrl: string): Promise<void> => {
             expect(localOriginUrl).toBeDefined();
-            expect(localOriginUrl.trim()).toEqual('git@github.com:collaborationFactory/rootRepo.git');
+            expect(localOriginUrl.trim()).toEqual(GIT_VIA_SSH_URI);
         };
 
         await testWith(basicTestSetupData)
@@ -48,25 +55,41 @@ describe('testing the repository helpers', () => {
             .evaluateWithRemoteAndLocalRepos(testGetRemoteOriginUrl, assertThatAValidRemoteIsGiven);
     });
 
-    test('test that getRemoteOriginUrl returns https if the local repo has https configured for git', async () => {
+    test('test getRemoteOriginUrl, local: https, remote: ssh -> https', async () => {
         const testGetRemoteOriginUrl = async (rootDir: string): Promise<string> => {
             // rewrite the remote url to git via https
-            await simpleGit(rootDir).remote(['set-url', 'origin', 'https://github.com/collaborationFactory/rootRepo.git'], (err, execResult: string) => {
-                if (err) {
-                    throw err;
-                } else {
-                    console.log('remote set-utl result:', execResult);
-                }
-            });
+            await remoteSetUrl(rootDir, GIT_VIA_HTTPS_URI);
+
             // assume the url in the parent repos would be for git via ssh
-            const result = await Repository.getRemoteOriginUrl(ROOT_REPO, `git@github.com:collaborationFactory/${ROOT_REPO}.git`, rootDir);
+            const result = await Repository.getRemoteOriginUrl(ROOT_REPO, GIT_VIA_SSH_URI, rootDir);
             console.log(result);
             return result;
         };
 
         const assertThatAValidRemoteIsGiven = async (localOriginUrl: string): Promise<void> => {
             expect(localOriginUrl).toBeDefined();
-            expect(localOriginUrl.trim()).toEqual('https://github.com/collaborationFactory/rootRepo.git');
+            expect(localOriginUrl.trim()).toEqual(GIT_VIA_HTTPS_URI);
+        };
+
+        await testWith(basicTestSetupData)
+            .withBranchUnderTest('release/22.2')
+            .evaluateWithRemoteAndLocalRepos(testGetRemoteOriginUrl, assertThatAValidRemoteIsGiven);
+    });
+
+    test('test getRemoteOriginUrl, local: ssh, remote: https -> https', async () => {
+        const testGetRemoteOriginUrl = async (rootDir: string): Promise<string> => {
+            // rewrite the remote url to git via ssh
+            await remoteSetUrl(rootDir, GIT_VIA_SSH_URI);
+
+            // assume the url in the parent repos would be for git via https
+            const result = await Repository.getRemoteOriginUrl(ROOT_REPO, GIT_VIA_HTTPS_URI, rootDir);
+            console.log(result);
+            return result;
+        };
+
+        const assertThatAValidRemoteIsGiven = async (localOriginUrl: string): Promise<void> => {
+            expect(localOriginUrl).toBeDefined();
+            expect(localOriginUrl.trim()).toEqual(GIT_VIA_HTTPS_URI);
         };
 
         await testWith(basicTestSetupData)

--- a/test/git/Repository.test.ts
+++ b/test/git/Repository.test.ts
@@ -1,0 +1,77 @@
+import {basicTestSetupData, ROOT_REPO, testWith} from '../helpers/remoteRepositories';
+import {Repository} from '../../src/git';
+import * as simpleGit from 'simple-git';
+
+describe('testing the repository helpers', () => {
+
+    test('test that the correct remote url is returned by getLocalOriginUrl', async () => {
+        const testGetLocalOriginUrl = async (rootDir: string): Promise<string> => {
+            const result = await Repository.getLocalOriginUrl(ROOT_REPO, rootDir);
+            console.log(result);
+            return result;
+        };
+
+        const assertThatAValidRemoteIsGiven = async (localOriginUrl: string): Promise<void> => {
+            expect(localOriginUrl).toBeDefined();
+            // The path would look like this on linux/osx:  /var/folders/jt/bcd1vz211hq913bbvmsvqd7h0000gn/T/1679059235280-cplace-cli-test-freeze-parent-repos/remote/rootRepo.git
+            expect(/^.*\/remote\/rootRepo.git$/.test(localOriginUrl.trim())).toBeTruthy();
+        };
+
+        await testWith(basicTestSetupData)
+            .withBranchUnderTest('release/22.2')
+            .evaluateWithRemoteAndLocalRepos(testGetLocalOriginUrl, assertThatAValidRemoteIsGiven);
+    });
+
+    test('test that getRemoteOriginUrl stays with git via ssh if the local repo has ssh configured for git', async () => {
+        const testGetRemoteOriginUrl = async (rootDir: string): Promise<string> => {
+            // rewrite the remote url to git via https
+            await simpleGit(rootDir).remote(['set-url', 'origin', 'git@github.com:collaborationFactory/rootRepo.git'], (err, execResult: string) => {
+                if (err) {
+                    throw err;
+                } else {
+                    console.log('remote set-utl result:', execResult);
+                }
+            });
+            // assume the url in the parent repos would be for git via ssh
+            const result = await Repository.getRemoteOriginUrl(ROOT_REPO, `git@github.com:collaborationFactory/${ROOT_REPO}.git`, rootDir);
+            console.log(result);
+            return result;
+        };
+
+        const assertThatAValidRemoteIsGiven = async (localOriginUrl: string): Promise<void> => {
+            expect(localOriginUrl).toBeDefined();
+            expect(localOriginUrl.trim()).toEqual('git@github.com:collaborationFactory/rootRepo.git');
+        };
+
+        await testWith(basicTestSetupData)
+            .withBranchUnderTest('release/22.2')
+            .evaluateWithRemoteAndLocalRepos(testGetRemoteOriginUrl, assertThatAValidRemoteIsGiven);
+    });
+
+    test('test that getRemoteOriginUrl returns https if the local repo has https configured for git', async () => {
+        const testGetRemoteOriginUrl = async (rootDir: string): Promise<string> => {
+            // rewrite the remote url to git via https
+            await simpleGit(rootDir).remote(['set-url', 'origin', 'https://github.com/collaborationFactory/rootRepo.git'], (err, execResult: string) => {
+                if (err) {
+                    throw err;
+                } else {
+                    console.log('remote set-utl result:', execResult);
+                }
+            });
+            // assume the url in the parent repos would be for git via ssh
+            const result = await Repository.getRemoteOriginUrl(ROOT_REPO, `git@github.com:collaborationFactory/${ROOT_REPO}.git`, rootDir);
+            console.log(result);
+            return result;
+        };
+
+        const assertThatAValidRemoteIsGiven = async (localOriginUrl: string): Promise<void> => {
+            expect(localOriginUrl).toBeDefined();
+            expect(localOriginUrl.trim()).toEqual('https://github.com/collaborationFactory/rootRepo.git');
+        };
+
+        await testWith(basicTestSetupData)
+            .withBranchUnderTest('release/22.2')
+            .evaluateWithRemoteAndLocalRepos(testGetRemoteOriginUrl, assertThatAValidRemoteIsGiven);
+    });
+
+});

--- a/test/repos/UpdateRepos.test.ts
+++ b/test/repos/UpdateRepos.test.ts
@@ -38,7 +38,7 @@ import * as path from 'path';
  * J) A customer branch with useSnapshot is configured
  *   -> should be updated on the latest HEAD of the customer branch
  *   -> NOTE: will fail if shallow cloned
-  * K) A customer branch is configured
+ * K) A customer branch is configured
  *   -> should be updated on the latest HEAD of the customer branch as remote tags are only resolved for release branches
  */
 


### PR DESCRIPTION
Resolves [PFM-ISSUE-12072](https://base.cplace.io/pages/rj736sfyph6lsl6mbdf8vcwis/PFM-ISSUE-12072-cplace-cli-fix-using-https-when-parent-repos.json-is-configured-for-ssh#id_wsrqdlqi9cus7fztqfsfa3gnz=cf.cplace.cfactoryPlatform.overview)

This fix needs to go into release/0.19 as it is already mandatory fro cplace release/23.1 which is on node 14.
Needs to be 'upmerged' to master.