### PR TITLE
PFM-ISSUE-12418: Replaced string comparison with number comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "cplace cli tools",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -113,7 +113,7 @@ export class Repository {
             } else if (tagMatches.groups.minor !== tagMarkerMatches.groups.minor) {
                 throw new Error(`[${repoName}]: Configured tagMarker ${repoProperties.tagMarker} does not match the minor version of the latest available tag ${repoProperties.latestTagForRelease}
                  for the release branch ${repoProperties.branch}! For consistency the tagMarker must have the same major and minor version as the release branch and the tag.`);
-            } else if (tagMatches.groups.patch < tagMarkerMatches.groups.patch) {
+            } else if (parseInt(tagMatches.groups.patch, 10) < parseInt(tagMarkerMatches.groups.patch, 10)) {
                 throw new Error(`[${repoName}]: Configured tagMarker ${repoProperties.tagMarker} has a higher patch version then the latest available tag ${repoProperties.latestTagForRelease}!`);
             }
         }


### PR DESCRIPTION
Resolves [PFM-ISSUE-12418](https://base.cplace.io/pages/6wghq4pv435iqm0yhi4p0qyw7/PFM-ISSUE-12418-Build-failed-Configured-tagMarker-version-23.1.9-has-a-higher-patch-version-then-the-latest-available-tag-version-23.1.10)