### PR TITLE
PFM-TASK-3600: cplace-cli: implement checking out a commit directly with the clone command

### DIFF
--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -86,6 +86,12 @@ export class Repository {
                                 .then(() => {
                                     resolve(newRepo);
                                 });
+                        } else if (repoProperties.commit) {
+                            Global.isVerbose() && console.log(`[${repoName}]:`, 'will update to the commit', repoProperties.commit);
+                            newRepo.checkoutCommit(repoProperties.commit)
+                                .then(() => {
+                                    resolve(newRepo);
+                                });
                         } else {
                             resolve(newRepo);
                         }
@@ -505,7 +511,7 @@ export class Repository {
                 });
             });
         } else {
-            Global.isVerbose() && console.log('[${this.repoName}]: no commit given');
+            Global.isVerbose() && console.log(`[${this.repoName}]: no commit given`);
             return Promise.resolve();
         }
     }

--- a/test/helpers/remoteRepositories.ts
+++ b/test/helpers/remoteRepositories.ts
@@ -146,7 +146,7 @@ export interface IRepoReleaseTestSetupData {
     releaseBranches: IBranchReleaseTestSetupData[];
 }
 
-interface ILocalRepoData {
+export interface ILocalRepoData {
     name: string;
     url: string;
 }
@@ -251,7 +251,7 @@ class EvaluateWithRemoteRepos implements ITestRun {
         return this;
     }
 
-    public evaluateWithRemoteRepos<T>(testCase: (rootDir: string) => Promise<T>, assertion: (testResult: T) => Promise<void>): Promise<void> {
+    public evaluateWithRemoteRepos<T>(testCase: (rootDir: string, remoteRepos?: ILocalRepoData[]) => Promise<T>, assertion: (testResult: T) => Promise<void>): Promise<void> {
         return withTempDirectory('freeze-parent-repos', this.testWithRemoteRepos, testCase, assertion).then(
             () => Promise.resolve(),
             (e) => {
@@ -273,7 +273,7 @@ class EvaluateWithRemoteRepos implements ITestRun {
             });
     }
 
-    private testWithRemoteRepos = async <T>(dir: string, testCase: (workingDir: string, remoteRepos: ILocalRepoData[]) => Promise<T>, assertion: (result: T) => Promise<void>) => {
+    private testWithRemoteRepos = async <T>(dir: string, testCase: (workingDir: string, remoteRepos?: ILocalRepoData[]) => Promise<T>, assertion: (result: T) => Promise<void>) => {
         const remoteRepos = this.createRemoteRepos(dir);
         const rootDir = this.createLocalRepos(dir, remoteRepos, false);
         try {


### PR DESCRIPTION
Resolves [PFM-TASK-3600](https://base.cplace.io/pages/u81vcbwpwehllguhkuxvhpx6x/PFM-TASK-3600-cplace-cli-implement-checking-out-a-commit-directly-with-the-clone-command)