### PR TITLE
PFM-ISSUE-14433: cplace-cli: fix wrong message when checking out a repo on a commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/cli",
-  "version": "0.19.24",
+  "version": "0.19.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/cli",
-  "version": "0.19.24",
+  "version": "0.19.25",
   "description": "cplace cli tools",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -49,8 +49,7 @@ export class Repository {
                 console.log(`[${repoName}]: will clone the latest HEAD of remote branch ${refToCheckout}, depth ${depth}, because useSnapshot is true.`);
             } else if (repoProperties.commit) {
                 refToCheckout = repoProperties.branch;
-                console.log(`[${repoName}]: will clone the latest HEAD of remote branch ${refToCheckout} because a commit is specified.
-                    Use the update command to checkout the required commits after cloning!`);
+                console.log(`[${repoName}]: will clone the latest HEAD of remote branch ${refToCheckout} because a commit is specified.`);
             } else if (repoProperties.tag) {
                 refToCheckout = repoProperties.tag;
                 refIsTag = true;
@@ -87,7 +86,7 @@ export class Repository {
                                     resolve(newRepo);
                                 });
                         } else if (repoProperties.commit) {
-                            Global.isVerbose() && console.log(`[${repoName}]:`, 'will update to the commit', repoProperties.commit);
+                            console.log(`[${repoName}]:`, 'will update to the commit', repoProperties.commit);
                             newRepo.checkoutCommit(repoProperties.commit)
                                 .then(() => {
                                     resolve(newRepo);


### PR DESCRIPTION
Resolves [PFM-ISSUE-14433](https://base.cplace.io/pages/98whzn2g07ai4jhnl35l5aorz/PFM-ISSUE-14433-cplace-cli-fix-wrong-message-when-checking-out-a-repo-on-a-commit)