### PR TITLE
PFM-ISSUE-27294 - cplace-cli: don't throw an error when freezing the parent-repos

### DIFF
--- a/src/commands/repos/WriteRepos.ts
+++ b/src/commands/repos/WriteRepos.ts
@@ -138,8 +138,7 @@ export class WriteRepos extends AbstractReposCommand {
                 try {
                     repo.checkBranchExistsOnRemote(status.current.trim());
                 } catch (e) {
-                    throw new Error(`[${repo.repoName}]: branch ${status.current} does not exist remotely. Consider to use the '--latest-tag' option in this case.
-                    See 'cplace-cli --help' for the 'repos --write' subcommand for details.`);
+                    console.warn(`[${repo.repoName}]: branch ${status.current} does not exist remotely. Consider to use the '--latest-tag' option in this case. See 'cplace-cli --help' for the 'repos --write' subcommand for details.`);
                 }
                 const result: IRepoStatus = {
                     url: current.url,


### PR DESCRIPTION
Resolves [PFM-ISSUE-27294](https://base.cplace.io/pages/h51v5geqi7bkhlu4w0uel72v3/PFM-ISSUE-27294-cplace-cli-don-t-throw-an-error-when-freezing-the-parent-repos)

Tested local:
- Generate release notes
- Write parent repos (all variants)
    - Initial error when writing the parents with 1.0.9 could be reproduced
- Repos 
  - clone and update
  - --validateBranches (basic test)
- branch (basic)
- Upmerge (basic)
