### PR TITLE
PFM-ISSUE-30326: CI/CD Build Fails Due to Outdated Parent Repository Version Detection

### DIFF
--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -191,7 +191,7 @@ export class Repository {
         return new Promise<string>((resolve, reject) => {
             Global.isVerbose() && console.log(`[${repoName}]: Getting the last tag with pattern ${tagPattern}:\n`);
             Repository.getRemoteOriginUrl(repoName, repoUrl, rootDir).then((remoteOriginUrl) => {
-                simpleGit.simpleGit().listRemote(['--tags', '--refs', '--sort=version:refname', remoteOriginUrl, tagPattern], (err, result: string) => {
+                simpleGit.simpleGit().listRemote(['--tags', '--refs', '--sort=-version:refname', remoteOriginUrl, tagPattern], (err, result: string) => {
                     if (err) {
                         Global.isVerbose() && console.log(`[${repoName}]:`, remoteOriginUrl, ': ls-remote failed!\n', err);
                         reject(err);


### PR DESCRIPTION
Resolves [PFM-ISSUE-30326](https://base.cplace.io/pages/oz7kxq944x2557o6ho3zd8591/PFM-ISSUE-30326-CI-CD-Build-Fails-Due-to-Outdated-Parent-Repository-Version-Detection-regarding-bcprov-jdk15on)