### PR TITLE
PFM-ISSUE-31133: Return value from checkBranchExists is not used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cplace/cli",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cplace/cli",
-      "version": "1.0.14",
+      "version": "1.0.16",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@inquirer/expand": "^4.0.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cplace/cli",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "cplace cli tools",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/commands/repos/WriteRepos.ts
+++ b/src/commands/repos/WriteRepos.ts
@@ -135,11 +135,12 @@ export class WriteRepos extends AbstractReposCommand {
             .getCurrentCommitHash()
             .then((commit) => {
                 const current = this.parentRepos[repo.repoName];
-                try {
-                    repo.checkBranchExistsOnRemote('origin', status.current.trim());
-                } catch (e) {
+
+                const branchExistsOnRemote: boolean = repo.checkBranchExistsOnRemote('origin', status.current.trim());
+                if (!branchExistsOnRemote) {
                     console.warn(`[${repo.repoName}]: branch ${status.current} does not exist remotely. Consider to use the '--latest-tag' option in this case. See 'cplace-cli --help' for the 'repos --write' subcommand for details.`);
                 }
+
                 const result: IRepoStatus = {
                     url: current.url,
                     branch: status.current,


### PR DESCRIPTION
Resolves [PFM-ISSUE-31133](https://base.cplace.io/pages/rkfy5kn28comcjwal54vfomcx/PFM-ISSUE-31133-cplace-cli-return-value-from-checkBranchExists-is-not-used)