### PR TITLE
GitBook migration preparation: Add content of the root index file from the docs repository

### DIFF
--- a/documentation/_index.md
+++ b/documentation/_index.md
@@ -4,4 +4,14 @@ description: "Command line utility to work with cplace code"
 weight: "140"
 type: "space"
 icon: "fal fa-terminal"
+language: "en"
 ---
+
+The cplace CLI tool provides a set of functions useful for working with cplace code.
+
+Using the tool you can, among other things,
+- create changelogs,
+- configure local Git repositories,
+- create a visualization of the Git branches,
+- perform upmerges,
+- and run e2e tests.


### PR DESCRIPTION
Part of the GitBook migration preparation: https://base.cplace.io/pages/uqh8hz40yn8zi7czash3hzv4r/Before-Migration-Prepare-repositories-before-migration