### PR TITLE
PFM-ISSUE-31861: Implement retry mechanism for git clone operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ $  cplace-cli --help
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
-                --git-retry-count sets the number of retry attempts for HTTP 404 errors
-                    (often temporary on remote git servers / load balancers).
-                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries). Set to 3 or higher to enable retries.
+                --max-attempts sets the maximum number of attempts for transient git/network errors
+                    (for example temporary HTTP 404 responses, timeouts, or connection errors).
+                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries).
+                    Set to 3 or higher to enable retries. Maximum: 10.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ $  cplace-cli --help
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
+                --git-retry-count sets the number of retry attempts for HTTP 404 errors
+                    (often temporary on remote git servers / load balancers).
+                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries). Set to 3 or higher to enable retries.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ $  cplace-cli --help
                     Ignored if If '--sequential' is set.
                     Default is 15.
                 --max-attempts sets the maximum number of attempts for transient git/network errors
-                    (for example temporary HTTP 404 responses, timeouts, or connection errors).
+                    (for example temporary HTTP 404 responses, connection timeouts, connection refused,
+                    or connection reset errors on remote git servers / load balancers).
                     Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries).
                     Set to 3 or higher to enable retries. Maximum: 10.
                 Clone behavior:

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ $  cplace-cli --help
                 --max-attempts sets the maximum number of attempts for transient git/network errors
                     (for example temporary HTTP 404 responses, connection timeouts, connection refused,
                     or connection reset errors on remote git servers / load balancers).
-                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries).
-                    Set to 3 or higher to enable retries. Maximum: 10.
+                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 3. Maximum: 10.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/documentation/list-of-available-commands/_index.md
+++ b/documentation/list-of-available-commands/_index.md
@@ -115,9 +115,9 @@ $  cplace-cli --help
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
-                If --git-retry-count is set, specifies the number of retry attempts for transient network errors
-                    (HTTP 404, timeouts, connection issues). Uses exponential backoff (2s, 4s, 8s, ...).
-                    Default: 3. Set to 1 to disable retries.
+                --git-retry-count sets the number of retry attempts for HTTP 404 errors
+                    (often temporary on remote git servers / load balancers).
+                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries). Set to 3 or higher to enable retries.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/documentation/list-of-available-commands/_index.md
+++ b/documentation/list-of-available-commands/_index.md
@@ -115,8 +115,9 @@ $  cplace-cli --help
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
-                --max-attempts sets the maximum number of attempts for transient git or network errors
-                    (for example temporary HTTP 404 responses, timeouts, or connection errors on remote git servers / load balancers).
+                --max-attempts sets the maximum number of attempts for transient git/network errors
+                    (for example temporary HTTP 404 responses, connection timeouts, connection refused,
+                    or connection reset errors on remote git servers / load balancers).
                     Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries).
                     Set to 3 or higher to enable retries. Maximum: 10.
                 Clone behavior:

--- a/documentation/list-of-available-commands/_index.md
+++ b/documentation/list-of-available-commands/_index.md
@@ -104,7 +104,7 @@ $  cplace-cli --help
                 If --freeze and --latest-tag are set, --latest-tag takes precedence. If there is no tag found for the parent repository
                     the commit hash will be added if the repository is checked out.
 
-            --clone|-c [--depth <depth>] [--sequential] [--concurrency] [--git-retry-count <count>]:
+            --clone|-c [--depth <depth>] [--sequential] [--concurrency] [--max-attempts <count>]:
                 Clones all parent repos if missing.
                 If --depth is set to a positive integer, a shallow clone with a history truncated to the specified number of commits is created.
                 The --depth parameter is ignored if a 'commit' is set to checkout in the parent repository.
@@ -115,9 +115,10 @@ $  cplace-cli --help
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
-                --git-retry-count sets the number of retry attempts for transient git or network errors
+                --max-attempts sets the maximum number of attempts for transient git or network errors
                     (for example temporary HTTP 404 responses, timeouts, or connection errors on remote git servers / load balancers).
-                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries). Set to 3 or higher to enable retries.
+                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries).
+                    Set to 3 or higher to enable retries. Maximum: 10.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/documentation/list-of-available-commands/_index.md
+++ b/documentation/list-of-available-commands/_index.md
@@ -115,8 +115,8 @@ $  cplace-cli --help
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
-                --git-retry-count sets the number of retry attempts for HTTP 404 errors
-                    (often temporary on remote git servers / load balancers).
+                --git-retry-count sets the number of retry attempts for transient git or network errors
+                    (for example temporary HTTP 404 responses, timeouts, or connection errors on remote git servers / load balancers).
                     Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries). Set to 3 or higher to enable retries.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,

--- a/documentation/list-of-available-commands/_index.md
+++ b/documentation/list-of-available-commands/_index.md
@@ -118,8 +118,7 @@ $  cplace-cli --help
                 --max-attempts sets the maximum number of attempts for transient git/network errors
                     (for example temporary HTTP 404 responses, connection timeouts, connection refused,
                     or connection reset errors on remote git servers / load balancers).
-                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries).
-                    Set to 3 or higher to enable retries. Maximum: 10.
+                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 3. Maximum: 10.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/documentation/list-of-available-commands/_index.md
+++ b/documentation/list-of-available-commands/_index.md
@@ -104,7 +104,7 @@ $  cplace-cli --help
                 If --freeze and --latest-tag are set, --latest-tag takes precedence. If there is no tag found for the parent repository
                     the commit hash will be added if the repository is checked out.
 
-            --clone|-c [--depth <depth>] [--sequential] [--concurrency]:
+            --clone|-c [--depth <depth>] [--sequential] [--concurrency] [--git-retry-count <count>]:
                 Clones all parent repos if missing.
                 If --depth is set to a positive integer, a shallow clone with a history truncated to the specified number of commits is created.
                 The --depth parameter is ignored if a 'commit' is set to checkout in the parent repository.
@@ -115,6 +115,9 @@ $  cplace-cli --help
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
+                If --git-retry-count is set, specifies the number of retry attempts for transient network errors
+                    (HTTP 404, timeouts, connection issues). Uses exponential backoff (2s, 4s, 8s, ...).
+                    Default: 3. Set to 1 to disable retries.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/src/Global.ts
+++ b/src/Global.ts
@@ -5,31 +5,17 @@ import {ICommandParameters} from './commands/models';
 
 export class Global {
     public static readonly PARAMETER_VERBOSE: string = 'verbose';
-    public static readonly PARAMETER_GIT_RETRY_COUNT: string = 'gitRetryCount';
     private static readonly instance: Global = new Global();
     private verbose: boolean;
-    private gitRetryCount: number;
 
     private constructor() {
     }
 
     public static parseParameters(params: ICommandParameters): void {
         Global.instance.verbose = !!params[Global.PARAMETER_VERBOSE];
-
-        // Parse git retry count with type validation and default
-        const retryCount = params[Global.PARAMETER_GIT_RETRY_COUNT];
-        if (typeof retryCount === 'number' && !isNaN(retryCount) && retryCount > 0) {
-            Global.instance.gitRetryCount = retryCount;
-        } else {
-            Global.instance.gitRetryCount = 3;
-        }
     }
 
     public static isVerbose(): boolean {
         return Global.instance.verbose;
-    }
-
-    public static getGitRetryCount(): number {
-        return Global.instance.gitRetryCount || 3;
     }
 }

--- a/src/Global.ts
+++ b/src/Global.ts
@@ -5,18 +5,31 @@ import {ICommandParameters} from './commands/models';
 
 export class Global {
     public static readonly PARAMETER_VERBOSE: string = 'verbose';
+    public static readonly PARAMETER_GIT_RETRY_COUNT: string = 'gitRetryCount';
     private static readonly instance: Global = new Global();
     private verbose: boolean;
+    private gitRetryCount: number;
 
     private constructor() {
     }
 
     public static parseParameters(params: ICommandParameters): void {
         Global.instance.verbose = !!params[Global.PARAMETER_VERBOSE];
+
+        // Parse git retry count with type validation and default
+        const retryCount = params[Global.PARAMETER_GIT_RETRY_COUNT];
+        if (typeof retryCount === 'number' && !isNaN(retryCount) && retryCount > 0) {
+            Global.instance.gitRetryCount = retryCount;
+        } else {
+            Global.instance.gitRetryCount = 3;
+        }
     }
 
     public static isVerbose(): boolean {
         return Global.instance.verbose;
     }
 
+    public static getGitRetryCount(): number {
+        return Global.instance.gitRetryCount || 3;
+    }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,7 +131,7 @@ const cli = meow(
                 If --freeze and --latest-tag are set, --latest-tag takes precedence. If there is no tag found for the parent repository
                     the commit hash will be added if the repository is checked out.
 
-            --clone|-c [--depth <depth>] [--sequential] [--concurrency] [--git-retry-count <count>]:
+            --clone|-c [--depth <depth>] [--sequential] [--concurrency] [--max-attempts <count>]:
                 Clones all parent repos if missing.
                 If --depth is set to a positive integer, a shallow clone with a history truncated to the specified number of commits is created.
                 The --depth parameter is ignored if a 'commit' is set to checkout in the parent repository.
@@ -142,10 +142,10 @@ const cli = meow(
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
-                --git-retry-count sets the number of retry attempts for transient git/network errors
+                --max-attempts sets the maximum number of attempts for transient git/network errors
                     such as HTTP 404 responses, connection errors, or timeouts (often temporary on remote
                     git servers / load balancers). Uses exponential backoff (2s, 4s, 8s, ...).
-                    Default: 1 (no retries). Set to 3 or higher to enable retries.
+                    Default: 1 (no retries). Set to 3 or higher to enable retries. Maximum: 10.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked
@@ -362,7 +362,7 @@ const cli = meow(
             release: {
                 type: 'string'
             },
-            gitRetryCount: {
+            maxAttempts: {
                 type: 'number'
             }
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,7 +146,7 @@ const cli = meow(
                     (for example temporary HTTP 404 responses, connection timeouts, connection refused,
                     or connection reset errors on remote git servers / load balancers).
                     Uses exponential backoff (2s, 4s, 8s, ...).
-                    Default: 1 (no retries). Set to 3 or higher to enable retries. Maximum: 10.
+                    Default: 1 (no retries). Set to 2 or higher to enable retries (recommended minimum: 3). Maximum: 10.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -351,12 +351,20 @@ const cli = meow(
     Global options:
         --verbose
             Print verbose information to console
+
+        --git-retry-count <count>
+            Number of retry attempts for git clone operations on transient network errors
+            (HTTP 404, timeouts, connection issues). Uses exponential backoff (2s, 4s, 8s, ...).
+            Default: 3. Set to 1 to disable retries.
 `,
     /* tslint:enable:no-trailing-whitespace */
     {
         flags: {
             release: {
                 type: 'string'
+            },
+            gitRetryCount: {
+                type: 'number'
             }
         }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,7 +131,7 @@ const cli = meow(
                 If --freeze and --latest-tag are set, --latest-tag takes precedence. If there is no tag found for the parent repository
                     the commit hash will be added if the repository is checked out.
 
-            --clone|-c [--depth <depth>] [--sequential] [--concurrency]:
+            --clone|-c [--depth <depth>] [--sequential] [--concurrency] [--git-retry-count <count>]:
                 Clones all parent repos if missing.
                 If --depth is set to a positive integer, a shallow clone with a history truncated to the specified number of commits is created.
                 The --depth parameter is ignored if a 'commit' is set to checkout in the parent repository.
@@ -142,6 +142,9 @@ const cli = meow(
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
+                If --git-retry-count is set, specifies the number of retry attempts for transient network errors
+                    (HTTP 404, timeouts, connection issues). Uses exponential backoff (2s, 4s, 8s, ...).
+                    Default: 3. Set to 1 to disable retries.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked
@@ -351,11 +354,6 @@ const cli = meow(
     Global options:
         --verbose
             Print verbose information to console
-
-        --git-retry-count <count>
-            Number of retry attempts for git clone operations on transient network errors
-            (HTTP 404, timeouts, connection issues). Uses exponential backoff (2s, 4s, 8s, ...).
-            Default: 3. Set to 1 to disable retries.
 `,
     /* tslint:enable:no-trailing-whitespace */
     {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,8 +143,9 @@ const cli = meow(
                     Ignored if If '--sequential' is set.
                     Default is 15.
                 --max-attempts sets the maximum number of attempts for transient git/network errors
-                    such as HTTP 404 responses, connection errors, or timeouts (often temporary on remote
-                    git servers / load balancers). Uses exponential backoff (2s, 4s, 8s, ...).
+                    (for example temporary HTTP 404 responses, connection timeouts, connection refused,
+                    or connection reset errors on remote git servers / load balancers).
+                    Uses exponential backoff (2s, 4s, 8s, ...).
                     Default: 1 (no retries). Set to 3 or higher to enable retries. Maximum: 10.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,7 +146,7 @@ const cli = meow(
                     (for example temporary HTTP 404 responses, connection timeouts, connection refused,
                     or connection reset errors on remote git servers / load balancers).
                     Uses exponential backoff (2s, 4s, 8s, ...).
-                    Default: 1 (no retries). Set to 2 or higher to enable retries (recommended minimum: 3). Maximum: 10.
+                    Default: 3. Maximum: 10.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,9 +142,10 @@ const cli = meow(
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
-                --git-retry-count sets the number of retry attempts for HTTP 404 errors
-                    (often temporary on remote git servers / load balancers).
-                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries). Set to 3 or higher to enable retries.
+                --git-retry-count sets the number of retry attempts for transient git/network errors
+                    such as HTTP 404 responses, connection errors, or timeouts (often temporary on remote
+                    git servers / load balancers). Uses exponential backoff (2s, 4s, 8s, ...).
+                    Default: 1 (no retries). Set to 3 or higher to enable retries.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,9 +142,9 @@ const cli = meow(
                     This allows to circumvent possible limits of remote api calls. Use 0 or negative values for unlimited concurrency.
                     Ignored if If '--sequential' is set.
                     Default is 15.
-                If --git-retry-count is set, specifies the number of retry attempts for transient network errors
-                    (HTTP 404, timeouts, connection issues). Uses exponential backoff (2s, 4s, 8s, ...).
-                    Default: 3. Set to 1 to disable retries.
+                --git-retry-count sets the number of retry attempts for HTTP 404 errors
+                    (often temporary on remote git servers / load balancers).
+                    Uses exponential backoff (2s, 4s, 8s, ...). Default: 1 (no retries). Set to 3 or higher to enable retries.
                 Clone behavior:
                 1. If a tag is configured for the parent repository it is cloned on that tag,
                 2. Else if a commit hash is configured, the repository is cloned to the HEAD of the branch. The specific commit needs to be checked

--- a/src/commands/repos/AbstractReposCommand.ts
+++ b/src/commands/repos/AbstractReposCommand.ts
@@ -68,7 +68,7 @@ export abstract class AbstractReposCommand implements ICommand {
         const maxAttempts = params[AbstractReposCommand.PARAMETER_MAX_ATTEMPTS];
         if (typeof maxAttempts === 'number' && !isNaN(maxAttempts) && maxAttempts >= 1) {
             if (maxAttempts > 10) {
-                throw new Error('maxAttempts must be between 1 and 10');
+                throw new Error(`maxAttempts value ${maxAttempts} must be between 1 and 10`);
             }
             this.maxAttempts = maxAttempts;
         } else {

--- a/src/commands/repos/AbstractReposCommand.ts
+++ b/src/commands/repos/AbstractReposCommand.ts
@@ -14,6 +14,7 @@ import {StatusResult} from 'simple-git';
 export abstract class AbstractReposCommand implements ICommand {
     public static readonly PARENT_REPOS_FILE_NAME: string = 'parent-repos.json';
     public static readonly PARAMETER_CLONE_DEPTH: string = 'depth';
+    public static readonly PARAMETER_GIT_RETRY_COUNT: string = 'gitRetryCount';
 
     protected static readonly PARAMETER_FORCE: string = 'force';
     protected static readonly PARAMETER_SEQUENTIAL: string = 'sequential';
@@ -25,6 +26,7 @@ export abstract class AbstractReposCommand implements ICommand {
     protected sequential: boolean;
     protected concurrency: number;
     protected depth: number;
+    protected gitRetryCount: number;
     protected parentReposConfigPath: string;
     protected rootDir: string;
 
@@ -62,6 +64,14 @@ export abstract class AbstractReposCommand implements ICommand {
         if (this.concurrency > 0) {
             Global.isVerbose() && console.log('running with concurrency for parallel execution = ' + this.concurrency);
         }
+
+        const gitRetryCount = params[AbstractReposCommand.PARAMETER_GIT_RETRY_COUNT];
+        if (typeof gitRetryCount === 'number' && !isNaN(gitRetryCount) && gitRetryCount >= 1) {
+            this.gitRetryCount = gitRetryCount;
+        } else {
+            this.gitRetryCount = 3;
+        }
+        Global.isVerbose() && console.log('running with git retry count = ' + this.gitRetryCount);
 
         this.parentReposConfigPath = path.join(this.rootDir, AbstractReposCommand.PARENT_REPOS_FILE_NAME);
         if (!fs.existsSync(this.parentReposConfigPath)) {

--- a/src/commands/repos/AbstractReposCommand.ts
+++ b/src/commands/repos/AbstractReposCommand.ts
@@ -14,7 +14,7 @@ import {StatusResult} from 'simple-git';
 export abstract class AbstractReposCommand implements ICommand {
     public static readonly PARENT_REPOS_FILE_NAME: string = 'parent-repos.json';
     public static readonly PARAMETER_CLONE_DEPTH: string = 'depth';
-    public static readonly PARAMETER_GIT_RETRY_COUNT: string = 'gitRetryCount';
+    public static readonly PARAMETER_MAX_ATTEMPTS: string = 'maxAttempts';
 
     protected static readonly PARAMETER_FORCE: string = 'force';
     protected static readonly PARAMETER_SEQUENTIAL: string = 'sequential';
@@ -26,7 +26,7 @@ export abstract class AbstractReposCommand implements ICommand {
     protected sequential: boolean;
     protected concurrency: number;
     protected depth: number;
-    protected gitRetryCount: number;
+    protected maxAttempts: number;
     protected parentReposConfigPath: string;
     protected rootDir: string;
 
@@ -65,13 +65,16 @@ export abstract class AbstractReposCommand implements ICommand {
             Global.isVerbose() && console.log('running with concurrency for parallel execution = ' + this.concurrency);
         }
 
-        const gitRetryCount = params[AbstractReposCommand.PARAMETER_GIT_RETRY_COUNT];
-        if (typeof gitRetryCount === 'number' && !isNaN(gitRetryCount) && gitRetryCount >= 1) {
-            this.gitRetryCount = gitRetryCount;
+        const maxAttempts = params[AbstractReposCommand.PARAMETER_MAX_ATTEMPTS];
+        if (typeof maxAttempts === 'number' && !isNaN(maxAttempts) && maxAttempts >= 1) {
+            if (maxAttempts > 10) {
+                throw new Error('maxAttempts must be between 1 and 10');
+            }
+            this.maxAttempts = maxAttempts;
         } else {
-            this.gitRetryCount = 1;
+            this.maxAttempts = 1;
         }
-        Global.isVerbose() && console.log('running with git retry count = ' + this.gitRetryCount);
+        Global.isVerbose() && console.log('running with max attempts = ' + this.maxAttempts);
 
         this.parentReposConfigPath = path.join(this.rootDir, AbstractReposCommand.PARENT_REPOS_FILE_NAME);
         if (!fs.existsSync(this.parentReposConfigPath)) {

--- a/src/commands/repos/AbstractReposCommand.ts
+++ b/src/commands/repos/AbstractReposCommand.ts
@@ -69,7 +69,7 @@ export abstract class AbstractReposCommand implements ICommand {
         if (typeof gitRetryCount === 'number' && !isNaN(gitRetryCount) && gitRetryCount >= 1) {
             this.gitRetryCount = gitRetryCount;
         } else {
-            this.gitRetryCount = 3;
+            this.gitRetryCount = 1;
         }
         Global.isVerbose() && console.log('running with git retry count = ' + this.gitRetryCount);
 

--- a/src/commands/repos/AbstractReposCommand.ts
+++ b/src/commands/repos/AbstractReposCommand.ts
@@ -15,6 +15,8 @@ export abstract class AbstractReposCommand implements ICommand {
     public static readonly PARENT_REPOS_FILE_NAME: string = 'parent-repos.json';
     public static readonly PARAMETER_CLONE_DEPTH: string = 'depth';
     public static readonly PARAMETER_MAX_ATTEMPTS: string = 'maxAttempts';
+    public static readonly MAX_ATTEMPTS_LIMIT: number = 10;
+    public static readonly MAX_ATTEMPTS_DEFAULT: number = 3;
 
     protected static readonly PARAMETER_FORCE: string = 'force';
     protected static readonly PARAMETER_SEQUENTIAL: string = 'sequential';
@@ -67,12 +69,12 @@ export abstract class AbstractReposCommand implements ICommand {
 
         const maxAttempts = params[AbstractReposCommand.PARAMETER_MAX_ATTEMPTS];
         if (typeof maxAttempts === 'number' && !isNaN(maxAttempts) && maxAttempts >= 1) {
-            if (maxAttempts > 10) {
-                throw new Error(`maxAttempts value ${maxAttempts} must be between 1 and 10`);
+            if (maxAttempts > AbstractReposCommand.MAX_ATTEMPTS_LIMIT) {
+                throw new Error(`maxAttempts value ${maxAttempts} must be between ${AbstractReposCommand.MAX_ATTEMPTS_DEFAULT} and ${AbstractReposCommand.MAX_ATTEMPTS_LIMIT}`);
             }
             this.maxAttempts = maxAttempts;
         } else {
-            this.maxAttempts = 1;
+            this.maxAttempts = AbstractReposCommand.MAX_ATTEMPTS_DEFAULT;
         }
         Global.isVerbose() && console.log('running with max attempts = ' + this.maxAttempts);
 

--- a/src/commands/repos/CloneRepos.ts
+++ b/src/commands/repos/CloneRepos.ts
@@ -37,11 +37,11 @@ export class CloneRepos extends AbstractReposCommand {
             return Repository.getLatestTagOfReleaseBranch(repoName, repoProperties, this.rootDir)
                 .then((latestTag) => {
                     repoProperties.latestTagForRelease = latestTag;
-                    return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth);
+                    return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth, this.gitRetryCount);
                 })
                 .catch((err) => Promise.reject(`[${repoName}]: failed to handle repo due to\n${err}`));
         } else {
-            return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth);
+            return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth, this.gitRetryCount);
         }
     }
 

--- a/src/commands/repos/CloneRepos.ts
+++ b/src/commands/repos/CloneRepos.ts
@@ -37,11 +37,11 @@ export class CloneRepos extends AbstractReposCommand {
             return Repository.getLatestTagOfReleaseBranch(repoName, repoProperties, this.rootDir)
                 .then((latestTag) => {
                     repoProperties.latestTagForRelease = latestTag;
-                    return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth, this.gitRetryCount);
+                    return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth, this.maxAttempts);
                 })
                 .catch((err) => Promise.reject(`[${repoName}]: failed to handle repo due to\n${err}`));
         } else {
-            return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth, this.gitRetryCount);
+            return Repository.clone(repoName, repoProperties, this.rootDir, toPath, depth, this.maxAttempts);
         }
     }
 

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -43,100 +43,32 @@ export class Repository {
         this.repoName = path.basename(path.resolve(repoPath));
     }
 
-    public static clone(repoName: string, repoProperties: IRepoStatus, rootDir: string, toPath: string, depth: number): Promise<Repository> {
-        return new Promise<Repository>((resolve, reject) => {
-            const options = [];
+    /**
+     * Clones a repository with the specified configuration.
+     *
+     * @param repoName - Name of the repository for logging
+     * @param repoProperties - Configuration including branch, tag, commit, url etc.
+     * @param rootDir - Root directory for resolving remote URL protocol
+     * @param toPath - Destination path for the cloned repository
+     * @param depth - Clone depth (0 for full clone)
+     * @param gitRetryCount - Number of retry attempts for transient errors (default: 3)
+     * @returns Promise resolving to the cloned Repository instance
+     */
+    public static async clone(
+        repoName: string,
+        repoProperties: IRepoStatus,
+        rootDir: string,
+        toPath: string,
+        depth: number,
+        gitRetryCount: number = 3
+    ): Promise<Repository> {
+        const { ref, isTag } = this.determineRefToCheckout(repoName, repoProperties, depth);
+        const options = this.buildCloneOptions(ref, depth, !!repoProperties.commit);
+        const remoteUrl = await this.getRemoteOriginUrl(repoName, repoProperties.url, rootDir);
 
-            let refToCheckout: string;
-            let refIsTag = false;
+        await this.cloneWithRetry(repoName, remoteUrl, toPath, options, gitRetryCount);
 
-            if (repoProperties.useSnapshot) {
-                refToCheckout = repoProperties.branch;
-                console.log(`[${repoName}]: will clone the latest HEAD of remote branch ${refToCheckout}, depth ${depth}, because useSnapshot is true.`);
-            } else if (repoProperties.commit) {
-                refToCheckout = repoProperties.branch;
-                console.log(`[${repoName}]: will clone the latest HEAD of remote branch ${refToCheckout} because a commit is specified.`);
-            } else if (repoProperties.tag) {
-                refToCheckout = repoProperties.tag;
-                refIsTag = true;
-                console.log(`[${repoName}]: will clone the tag ${refToCheckout} with depth ${depth} as configured.`);
-            } else if (repoProperties.latestTagForRelease) {
-                refToCheckout = repoProperties.latestTagForRelease;
-                this.validateTagMarker(repoProperties, repoName);
-
-                refIsTag = true;
-                console.log(`[${repoName}]: will clone the latestTagForRelease ${refToCheckout}, depth ${depth}.`);
-            } else if (repoProperties.branch) {
-                refToCheckout = repoProperties.branch;
-                console.log(`[${repoName}]: will clone the latest HEAD of remote branch ${refToCheckout}, depth ${depth}, because no latestTagForRelease was found and only a branch is configured.`);
-            } else {
-                console.log(`[${repoName}]: will clone the latest HEAD of the default branch with depth ${depth} because not even a branch is configured.`);
-            }
-
-            if (refToCheckout) {
-                options.push('--branch', refToCheckout);
-            }
-            if (depth > 0 && !repoProperties.commit) {
-                options.push('--depth', depth.toString(10));
-            }
-
-            Repository.getRemoteOriginUrl(repoName, repoProperties.url, rootDir).then((remoteOriginUrl) => {
-                const maxRetries = Global.getGitRetryCount();
-                let attemptNumber = 0;
-
-                const attemptClone = () => {
-                    attemptNumber++;
-                    const isRetry = attemptNumber > 1;
-
-                    if (isRetry) {
-                        console.log(`[${repoName}]:`, `Clone attempt ${attemptNumber}/${maxRetries}...`);
-                    }
-
-                    simpleGit.simpleGit().clone(remoteOriginUrl, toPath, options, (err) => {
-                        if (err) {
-                            // Check if error is transient and we have retries left
-                            if (Repository.isTransientCloneError(err) && attemptNumber < maxRetries) {
-                                const delayMs = Math.pow(2, attemptNumber) * 1000; // 2s, 4s, 8s, etc.
-                                console.warn(`[${repoName}]:`, `Clone failed with transient error (attempt ${attemptNumber}/${maxRetries}): ${err.message || err}`);
-                                console.log(`[${repoName}]:`, `Retrying in ${delayMs / 1000} seconds...`);
-
-                                Repository.delay(delayMs).then(() => attemptClone());
-                            } else {
-                                // No more retries or permanent error
-                                if (attemptNumber >= maxRetries && Repository.isTransientCloneError(err)) {
-                                    console.error(`[${repoName}]:`, `Clone failed after ${maxRetries} attempts`);
-                                }
-                                reject(err);
-                            }
-                        } else {
-                            // Success
-                            if (isRetry) {
-                                console.log(`[${repoName}]:`, `Clone succeeded on attempt ${attemptNumber}`);
-                            }
-
-                            const newRepo = new Repository(toPath);
-                            if (refIsTag) {
-                                newRepo.createBranchForTag(repoName, refToCheckout)
-                                    .then(() => {
-                                        resolve(newRepo);
-                                    });
-                            } else if (repoProperties.commit) {
-                                console.log(`[${repoName}]:`, 'will update to the commit', repoProperties.commit);
-                                newRepo.checkoutCommit(repoProperties.commit)
-                                    .then(() => {
-                                        resolve(newRepo);
-                                    });
-                            } else {
-                                resolve(newRepo);
-                            }
-                        }
-                    });
-                };
-
-                // Start first attempt
-                attemptClone();
-            });
-        });
+        return this.setupClonedRepo(repoName, toPath, repoProperties, ref, isTag);
     }
 
     /**
@@ -169,16 +101,13 @@ export class Repository {
         }
 
         // Git-specific temporary errors
-        if (errorMsg.includes('Could not resolve host') ||
+        return errorMsg.includes('Could not resolve host') ||
             errorMsg.includes('Failed to connect') ||
             errorMsg.includes('RPC failed') ||
             errorMsg.includes('The remote end hung up') ||
             errorMsg.includes('early EOF') ||
-            errorMsg.includes('index-pack failed')) {
-            return true;
-        }
+            errorMsg.includes('index-pack failed');
 
-        return false;
     }
 
     /**
@@ -186,6 +115,133 @@ export class Repository {
      */
     private static delay(ms: number): Promise<void> {
         return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    /**
+     * Determines which ref (branch or tag) to checkout based on repo properties.
+     * Returns the ref name and whether it's a tag.
+     */
+    private static determineRefToCheckout(
+        repoName: string,
+        repoProperties: IRepoStatus,
+        depth: number
+    ): { ref: string | undefined; isTag: boolean } {
+        let ref: string | undefined;
+        let isTag = false;
+
+        if (repoProperties.useSnapshot) {
+            ref = repoProperties.branch;
+            console.log(`[${repoName}]: will clone the latest HEAD of remote branch ${ref}, depth ${depth}, because useSnapshot is true.`);
+        } else if (repoProperties.commit) {
+            ref = repoProperties.branch;
+            console.log(`[${repoName}]: will clone the latest HEAD of remote branch ${ref} because a commit is specified.`);
+        } else if (repoProperties.tag) {
+            ref = repoProperties.tag;
+            isTag = true;
+            console.log(`[${repoName}]: will clone the tag ${ref} with depth ${depth} as configured.`);
+        } else if (repoProperties.latestTagForRelease) {
+            ref = repoProperties.latestTagForRelease;
+            this.validateTagMarker(repoProperties, repoName);
+            isTag = true;
+            console.log(`[${repoName}]: will clone the latestTagForRelease ${ref}, depth ${depth}.`);
+        } else if (repoProperties.branch) {
+            ref = repoProperties.branch;
+            console.log(`[${repoName}]: will clone the latest HEAD of remote branch ${ref}, depth ${depth}, because no latestTagForRelease was found and only a branch is configured.`);
+        } else {
+            console.log(`[${repoName}]: will clone the latest HEAD of the default branch with depth ${depth} because not even a branch is configured.`);
+        }
+
+        return { ref, isTag };
+    }
+
+    /**
+     * Builds the clone options array based on ref and depth settings.
+     */
+    private static buildCloneOptions(
+        ref: string | undefined,
+        depth: number,
+        hasCommit: boolean
+    ): string[] {
+        const options: string[] = [];
+
+        if (ref) {
+            options.push('--branch', ref);
+        }
+        if (depth > 0 && !hasCommit) {
+            options.push('--depth', depth.toString(10));
+        }
+
+        return options;
+    }
+
+    /**
+     * Executes git clone with retry logic for transient errors.
+     * Uses exponential backoff between retry attempts.
+     */
+    private static async cloneWithRetry(
+        repoName: string,
+        remoteUrl: string,
+        toPath: string,
+        options: string[],
+        maxRetries: number
+    ): Promise<void> {
+
+        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                await new Promise<void>((resolve, reject) => {
+                    simpleGit.simpleGit().clone(remoteUrl, toPath, options, (err) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve();
+                        }
+                    });
+                });
+
+                if (attempt > 1) {
+                    console.log(`[${repoName}]:`, `Clone succeeded on attempt ${attempt}`);
+                }
+                return; // Success - exit the retry loop
+
+            } catch (err) {
+                const isTransient = this.isTransientCloneError(err);
+                const hasRetriesLeft = attempt < maxRetries;
+
+                if (isTransient && hasRetriesLeft) {
+                    const delayMs = Math.pow(2, attempt) * 1000; // 2s, 4s, 8s, etc.
+                    console.warn(`[${repoName}]:`, `Clone failed with transient error (attempt ${attempt}/${maxRetries}): ${err.message || err}`);
+                    console.log(`[${repoName}]:`, `Retrying in ${delayMs / 1000} seconds...`);
+                    await this.delay(delayMs);
+                } else {
+                    if (attempt >= maxRetries && isTransient) {
+                        console.error(`[${repoName}]:`, `Clone failed after ${maxRetries} attempts`);
+                    }
+                    throw err;
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets up the cloned repository by creating branches for tags or checking out specific commits.
+     */
+    private static async setupClonedRepo(
+        repoName: string,
+        toPath: string,
+        repoProperties: IRepoStatus,
+        ref: string | undefined,
+        isTag: boolean
+    ): Promise<Repository> {
+        const newRepo = new Repository(toPath);
+
+        if (isTag && ref) {
+            await newRepo.createBranchForTag(repoName, ref);
+        } else if (repoProperties.commit) {
+            console.log(`[${repoName}]:`, 'will update to the commit', repoProperties.commit);
+            await newRepo.checkoutCommit(repoProperties.commit);
+        }
+
+        return newRepo;
     }
 
     public static validateTagMarker(repoProperties: IRepoStatus, repoName: string): void {
@@ -635,11 +691,11 @@ export class Repository {
     public async merge(remote: string | null, otherBranch: string, opts?: { noFF?: boolean, ffOnly?: boolean, noEdit?: boolean, listFiles?: boolean, noCommit?: boolean }): Promise<void> {
         opts = opts || {};
         Global.isVerbose() && console.log(`[${this.repoName}]: merge ${this.repoName}, otherBranch `, otherBranch);
-        
+
         // Check if the branch exists locally or on the remote
         const existsLocally = await this.checkBranchExistsLocally(otherBranch);
         const existsOnRemote = this.checkBranchExistsOnRemote(remote, otherBranch);
-        
+
         if (!existsLocally && !existsOnRemote) {
             const errorMessage = `Branch '${otherBranch}' does not exist locally or on the remote`;
             console.error(`[${this.repoName}]: ${errorMessage}`);
@@ -652,7 +708,7 @@ export class Repository {
         opts.noEdit && options.push('--no-edit');
         opts.noCommit && options.push('--no-commit');
         options.push('--allow-unrelated-histories');
-        
+
         let mergeData;
         try {
             mergeData = await new Promise<any>((resolve, reject) => {

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -79,14 +79,17 @@ export class Repository {
         if (!error) {
             return false;
         }
-        const errorMsg = error.message || error.toString();
+        const errorMsg = (error.message || error.toString()).toLowerCase();
 
         // HTTP 404 errors (often temporary on remote git servers / load balancers)
-        if (errorMsg.includes('404') ||  errorMsg.toLowerCase().includes('not found')) {
+        if (errorMsg.includes('404') || errorMsg.includes('not found')) {
             return true;
         }
 
-        return false;
+        // Network timeouts and connection errors
+        return errorMsg.includes('etimedout') || errorMsg.includes('econnrefused') ||
+            errorMsg.includes('econnreset') || errorMsg.includes('timeout');
+
     }
 
     /**
@@ -183,16 +186,16 @@ export class Repository {
                 return; // Success - exit the retry loop
 
             } catch (err) {
-                const isTransient = this.isRetryableGitError(err);
+                const isRetryableError = this.isRetryableGitError(err);
                 const hasRetriesLeft = attempt < maxRetries;
 
-                if (isTransient && hasRetriesLeft) {
+                if (isRetryableError && hasRetriesLeft) {
                     const delayMs = Math.pow(2, attempt) * 1000; // 2s, 4s, 8s, etc.
                     console.warn(`[${repoName}]:`, `Clone failed with transient error (attempt ${attempt}/${maxRetries}): ${err.message || err}`);
                     console.log(`[${repoName}]:`, `Retrying in ${delayMs / 1000} seconds...`);
                     await this.delay(delayMs);
                 } else {
-                    if (attempt >= maxRetries && isTransient) {
+                    if (attempt >= maxRetries && isRetryableError) {
                         console.error(`[${repoName}]:`, `Clone failed after ${maxRetries} attempts`);
                     }
                     throw err;

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -51,7 +51,7 @@ export class Repository {
      * @param rootDir - Root directory for resolving remote URL protocol
      * @param toPath - Destination path for the cloned repository
      * @param depth - Clone depth (0 for full clone)
-     * @param gitRetryCount - Number of retry attempts for HTTP 404 errors (default: 1, no retries)
+     * @param gitRetryCount - Number of retry attempts for transient errors (HTTP 404, timeouts, connection failures) (default: 1, no retries)
      * @returns Promise resolving to the cloned Repository instance
      */
     public static async clone(

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -203,7 +203,7 @@ export class Repository {
                     console.log(`[${repoName}]:`, `Retrying in ${delayMs / 1000} seconds...`);
                     await this.delay(delayMs);
                 } else {
-                    if (attempt >= maxAttempts && isRetryableError) {
+                    if (isRetryableError && !hasAttemptsLeft) {
                         console.error(`[${repoName}]:`, `Clone failed after ${maxAttempts} attempts`);
                     }
                     throw err;

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -51,7 +51,7 @@ export class Repository {
      * @param rootDir - Root directory for resolving remote URL protocol
      * @param toPath - Destination path for the cloned repository
      * @param depth - Clone depth (0 for full clone)
-     * @param gitRetryCount - Number of retry attempts for transient errors (default: 3)
+     * @param gitRetryCount - Number of retry attempts for HTTP 404 errors (default: 1, no retries)
      * @returns Promise resolving to the cloned Repository instance
      */
     public static async clone(
@@ -60,7 +60,7 @@ export class Repository {
         rootDir: string,
         toPath: string,
         depth: number,
-        gitRetryCount: number = 3
+        gitRetryCount: number = 1
     ): Promise<Repository> {
         const { ref, isTag } = this.determineRefToCheckout(repoName, repoProperties, depth);
         const options = this.buildCloneOptions(ref, depth, !!repoProperties.commit);
@@ -72,42 +72,21 @@ export class Repository {
     }
 
     /**
-     * Checks if the given error is a transient error that should be retried.
-     * Transient errors include network issues, temporary server errors, and Git RPC failures.
+     * Determines if the given error is retryable.
+     * Retryable errors include network timeouts, connection failures, HTTP 404s, and Git RPC issues.
      */
-    private static isTransientCloneError(error: any): boolean {
+    private static isRetryableGitError(error: any): boolean {
         if (!error) {
             return false;
         }
-
         const errorMsg = error.message || error.toString();
 
         // HTTP 404 errors (often temporary on remote git servers / load balancers)
-        if (errorMsg.includes('404') || errorMsg.includes('Not Found')) {
+        if (errorMsg.includes('404') ||  errorMsg.toLowerCase().includes('not found')) {
             return true;
         }
 
-        // Network timeout errors
-        if (errorMsg.includes('ETIMEDOUT') || errorMsg.includes('timed out')) {
-            return true;
-        }
-
-        // Connection errors
-        if (errorMsg.includes('ECONNREFUSED') ||
-            errorMsg.includes('ENOTFOUND') ||
-            errorMsg.includes('ECONNRESET') ||
-            errorMsg.includes('connection refused')) {
-            return true;
-        }
-
-        // Git-specific temporary errors
-        return errorMsg.includes('Could not resolve host') ||
-            errorMsg.includes('Failed to connect') ||
-            errorMsg.includes('RPC failed') ||
-            errorMsg.includes('The remote end hung up') ||
-            errorMsg.includes('early EOF') ||
-            errorMsg.includes('index-pack failed');
-
+        return false;
     }
 
     /**
@@ -198,13 +177,13 @@ export class Repository {
                     });
                 });
 
-                if (attempt > 1) {
+                if (attempt > 0) {
                     console.log(`[${repoName}]:`, `Clone succeeded on attempt ${attempt}`);
                 }
                 return; // Success - exit the retry loop
 
             } catch (err) {
-                const isTransient = this.isTransientCloneError(err);
+                const isTransient = this.isRetryableGitError(err);
                 const hasRetriesLeft = attempt < maxRetries;
 
                 if (isTransient && hasRetriesLeft) {
@@ -593,9 +572,9 @@ export class Repository {
      * The fetch will be done with a depth of 1.
      * @param branch the branch to fetch from the remote
      */
-    public prefetchBranchForShallowClone(branch: string): Promise<void> {
+    public async prefetchBranchForShallowClone(branch: string): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            this.git.revparse(['--is-shallow-repository'], (err, data) => {
+            this.git.revparse(['--is-shallow-repository'], async (err, data) => {
                 if (err) {
                     reject(err);
                 } else if (data?.trim() === 'true') {
@@ -606,9 +585,13 @@ export class Repository {
                     The named branches will be interpreted as if specified with the -t option on the git remote add command line.
                     With --add, instead of replacing the list of currently tracked branches, adds to that list.
                      */
-                    this.git.remote(['set-branches', '--add', 'origin', branch]);
-                    this.git.fetch(['--depth', '1']);
-                    resolve();
+                    try {
+                        await this.git.remote(['set-branches', '--add', 'origin', branch]);
+                        await this.git.fetch(['--depth', '1']);
+                        resolve();
+                    } catch (fetchErr) {
+                        reject(fetchErr);
+                    }
                 } else {
                     resolve();
                 }

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -180,7 +180,7 @@ export class Repository {
                     });
                 });
 
-                if (attempt > 0) {
+                if (attempt > 1) {
                     console.log(`[${repoName}]:`, `Clone succeeded on attempt ${attempt}`);
                 }
                 return; // Success - exit the retry loop

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -81,29 +81,111 @@ export class Repository {
             }
 
             Repository.getRemoteOriginUrl(repoName, repoProperties.url, rootDir).then((remoteOriginUrl) => {
-                simpleGit.simpleGit().clone(remoteOriginUrl, toPath, options, (err) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        const newRepo = new Repository(toPath);
-                        if (refIsTag) {
-                            newRepo.createBranchForTag(repoName, refToCheckout)
-                                .then(() => {
-                                    resolve(newRepo);
-                                });
-                        } else if (repoProperties.commit) {
-                            console.log(`[${repoName}]:`, 'will update to the commit', repoProperties.commit);
-                            newRepo.checkoutCommit(repoProperties.commit)
-                                .then(() => {
-                                    resolve(newRepo);
-                                });
-                        } else {
-                            resolve(newRepo);
-                        }
+                const maxRetries = Global.getGitRetryCount();
+                let attemptNumber = 0;
+
+                const attemptClone = () => {
+                    attemptNumber++;
+                    const isRetry = attemptNumber > 1;
+
+                    if (isRetry) {
+                        console.log(`[${repoName}]:`, `Clone attempt ${attemptNumber}/${maxRetries}...`);
                     }
-                });
+
+                    simpleGit.simpleGit().clone(remoteOriginUrl, toPath, options, (err) => {
+                        if (err) {
+                            // Check if error is transient and we have retries left
+                            if (Repository.isTransientCloneError(err) && attemptNumber < maxRetries) {
+                                const delayMs = Math.pow(2, attemptNumber) * 1000; // 2s, 4s, 8s, etc.
+                                console.warn(`[${repoName}]:`, `Clone failed with transient error (attempt ${attemptNumber}/${maxRetries}): ${err.message || err}`);
+                                console.log(`[${repoName}]:`, `Retrying in ${delayMs / 1000} seconds...`);
+
+                                Repository.delay(delayMs).then(() => attemptClone());
+                            } else {
+                                // No more retries or permanent error
+                                if (attemptNumber >= maxRetries && Repository.isTransientCloneError(err)) {
+                                    console.error(`[${repoName}]:`, `Clone failed after ${maxRetries} attempts`);
+                                }
+                                reject(err);
+                            }
+                        } else {
+                            // Success
+                            if (isRetry) {
+                                console.log(`[${repoName}]:`, `Clone succeeded on attempt ${attemptNumber}`);
+                            }
+
+                            const newRepo = new Repository(toPath);
+                            if (refIsTag) {
+                                newRepo.createBranchForTag(repoName, refToCheckout)
+                                    .then(() => {
+                                        resolve(newRepo);
+                                    });
+                            } else if (repoProperties.commit) {
+                                console.log(`[${repoName}]:`, 'will update to the commit', repoProperties.commit);
+                                newRepo.checkoutCommit(repoProperties.commit)
+                                    .then(() => {
+                                        resolve(newRepo);
+                                    });
+                            } else {
+                                resolve(newRepo);
+                            }
+                        }
+                    });
+                };
+
+                // Start first attempt
+                attemptClone();
             });
         });
+    }
+
+    /**
+     * Checks if the given error is a transient error that should be retried.
+     * Transient errors include network issues, temporary server errors, and Git RPC failures.
+     */
+    private static isTransientCloneError(error: any): boolean {
+        if (!error) {
+            return false;
+        }
+
+        const errorMsg = error.message || error.toString();
+
+        // HTTP 404 errors (often temporary on remote git servers / load balancers)
+        if (errorMsg.includes('404') || errorMsg.includes('Not Found')) {
+            return true;
+        }
+
+        // Network timeout errors
+        if (errorMsg.includes('ETIMEDOUT') || errorMsg.includes('timed out')) {
+            return true;
+        }
+
+        // Connection errors
+        if (errorMsg.includes('ECONNREFUSED') ||
+            errorMsg.includes('ENOTFOUND') ||
+            errorMsg.includes('ECONNRESET') ||
+            errorMsg.includes('connection refused')) {
+            return true;
+        }
+
+        // Git-specific temporary errors
+        if (errorMsg.includes('Could not resolve host') ||
+            errorMsg.includes('Failed to connect') ||
+            errorMsg.includes('RPC failed') ||
+            errorMsg.includes('The remote end hung up') ||
+            errorMsg.includes('early EOF') ||
+            errorMsg.includes('index-pack failed')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Delay helper for exponential backoff
+     */
+    private static delay(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
     }
 
     public static validateTagMarker(repoProperties: IRepoStatus, repoName: string): void {

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -583,9 +583,9 @@ export class Repository {
      * The fetch will be done with a depth of 1.
      * @param branch the branch to fetch from the remote
      */
-    public async prefetchBranchForShallowClone(branch: string): Promise<void> {
+    public prefetchBranchForShallowClone(branch: string): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            this.git.revparse(['--is-shallow-repository'], async (err, data) => {
+            this.git.revparse(['--is-shallow-repository'], (err, data) => {
                 if (err) {
                     reject(err);
                 } else if (data?.trim() === 'true') {
@@ -596,13 +596,20 @@ export class Repository {
                     The named branches will be interpreted as if specified with the -t option on the git remote add command line.
                     With --add, instead of replacing the list of currently tracked branches, adds to that list.
                      */
-                    try {
-                        await this.git.remote(['set-branches', '--add', 'origin', branch]);
-                        await this.git.fetch(['--depth', '1']);
-                        resolve();
-                    } catch (fetchErr) {
-                        reject(fetchErr);
-                    }
+                    this.git.remote(['set-branches', '--add', 'origin', branch], (remoteErr) => {
+                        if (remoteErr) {
+                            reject(remoteErr);
+                        } else {
+                            // Fetch only the specific branch to avoid "Cannot fast-forward to multiple branches" error
+                            this.git.fetch(['--depth', '1', 'origin', branch], (fetchErr) => {
+                                if (fetchErr) {
+                                    reject(fetchErr);
+                                } else {
+                                    resolve();
+                                }
+                            });
+                        }
+                    });
                 } else {
                     resolve();
                 }

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -82,7 +82,15 @@ export class Repository {
         const errorMsg = (error.message || error.toString()).toLowerCase();
 
         // HTTP 404 errors (often temporary on remote git servers / load balancers)
-        if (errorMsg.includes('404') || errorMsg.includes('not found')) {
+        const isHttp404 = errorMsg.includes('404');
+
+        // Git-specific "not found" errors (avoid matching unrelated "not found" messages)
+        const isGitNotFound =
+            errorMsg.includes('repository not found') ||
+            errorMsg.includes('remote: repository not found') ||
+            errorMsg.includes('remote: not found');
+
+        if (isHttp404 || isGitNotFound) {
             return true;
         }
 

--- a/src/git/Repository.ts
+++ b/src/git/Repository.ts
@@ -51,7 +51,7 @@ export class Repository {
      * @param rootDir - Root directory for resolving remote URL protocol
      * @param toPath - Destination path for the cloned repository
      * @param depth - Clone depth (0 for full clone)
-     * @param gitRetryCount - Number of retry attempts for transient errors (HTTP 404, timeouts, connection failures) (default: 1, no retries)
+     * @param maxAttempts - Maximum number of attempts for transient errors (HTTP 404, timeouts, connection failures) (default: 1, no retries)
      * @returns Promise resolving to the cloned Repository instance
      */
     public static async clone(
@@ -60,13 +60,13 @@ export class Repository {
         rootDir: string,
         toPath: string,
         depth: number,
-        gitRetryCount: number = 1
+        maxAttempts: number = 1
     ): Promise<Repository> {
         const { ref, isTag } = this.determineRefToCheckout(repoName, repoProperties, depth);
         const options = this.buildCloneOptions(ref, depth, !!repoProperties.commit);
         const remoteUrl = await this.getRemoteOriginUrl(repoName, repoProperties.url, rootDir);
 
-        await this.cloneWithRetry(repoName, remoteUrl, toPath, options, gitRetryCount);
+        await this.cloneWithRetry(repoName, remoteUrl, toPath, options, maxAttempts);
 
         return this.setupClonedRepo(repoName, toPath, repoProperties, ref, isTag);
     }
@@ -173,10 +173,10 @@ export class Repository {
         remoteUrl: string,
         toPath: string,
         options: string[],
-        maxRetries: number
+        maxAttempts: number
     ): Promise<void> {
 
-        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
             try {
                 await new Promise<void>((resolve, reject) => {
                     simpleGit.simpleGit().clone(remoteUrl, toPath, options, (err) => {
@@ -195,16 +195,16 @@ export class Repository {
 
             } catch (err) {
                 const isRetryableError = this.isRetryableGitError(err);
-                const hasRetriesLeft = attempt < maxRetries;
+                const hasAttemptsLeft = attempt < maxAttempts;
 
-                if (isRetryableError && hasRetriesLeft) {
+                if (isRetryableError && hasAttemptsLeft) {
                     const delayMs = Math.pow(2, attempt) * 1000; // 2s, 4s, 8s, etc.
-                    console.warn(`[${repoName}]:`, `Clone failed with transient error (attempt ${attempt}/${maxRetries}): ${err.message || err}`);
+                    console.warn(`[${repoName}]:`, `Clone failed with transient error (attempt ${attempt}/${maxAttempts}): ${err.message || err}`);
                     console.log(`[${repoName}]:`, `Retrying in ${delayMs / 1000} seconds...`);
                     await this.delay(delayMs);
                 } else {
-                    if (attempt >= maxRetries && isRetryableError) {
-                        console.error(`[${repoName}]:`, `Clone failed after ${maxRetries} attempts`);
+                    if (attempt >= maxAttempts && isRetryableError) {
+                        console.error(`[${repoName}]:`, `Clone failed after ${maxAttempts} attempts`);
                     }
                     throw err;
                 }

--- a/test/git/Repository.retry.test.ts
+++ b/test/git/Repository.retry.test.ts
@@ -1,0 +1,290 @@
+import { Repository } from '../../src/git/Repository';
+import * as simpleGit from 'simple-git';
+
+jest.mock('simple-git');
+
+const mockedSimpleGit = simpleGit as jest.Mocked<typeof simpleGit>;
+
+describe('Repository retry logic', () => {
+
+    describe('isRetryableGitError', () => {
+        // Access private static method for testing
+        const isRetryableGitError = (error: any): boolean => {
+            return (Repository as any)['isRetryableGitError'](error);
+        };
+
+        // Parameterized tests for retryable errors
+        const retryableErrors: [string, string][] = [
+            // HTTP 404 errors
+            ['HTTP 404 error', 'error: 404 Not Found'],
+            ['plain 404 in message', 'HTTP 404'],
+            // Git repository not found errors
+            ['repository not found', 'repository not found'],
+            ['remote: repository not found', 'remote: repository not found'],
+            ['remote: not found', 'remote: not found'],
+            // Network timeout and connection errors
+            ['ETIMEDOUT', 'connect ETIMEDOUT'],
+            ['ECONNREFUSED', 'connect ECONNREFUSED 127.0.0.1:443'],
+            ['ECONNRESET', 'read ECONNRESET'],
+            ['generic timeout', 'Connection timeout after 30000ms'],
+            // Case insensitivity
+            ['uppercase REPOSITORY NOT FOUND', 'REPOSITORY NOT FOUND'],
+            ['mixed case Remote: Repository Not Found', 'Remote: Repository Not Found'],
+            ['uppercase ETIMEDOUT', 'ETIMEDOUT'],
+        ];
+
+        test.each(retryableErrors)(
+            'should return true for %s',
+            (_description, errorMessage) => {
+                expect(isRetryableGitError({ message: errorMessage })).toBe(true);
+            }
+        );
+
+        // Parameterized tests for non-retryable errors
+        const nonRetryableErrors: [string, string][] = [
+            ['permission denied', 'Permission denied (publickey)'],
+            ['authentication failed', 'Authentication failed'],
+            ['invalid repository', 'fatal: not a git repository'],
+            ['merge conflicts', 'CONFLICT (content): Merge conflict in file.txt'],
+            ['empty message', ''],
+        ];
+
+        test.each(nonRetryableErrors)(
+            'should return false for %s',
+            (_description, errorMessage) => {
+                expect(isRetryableGitError({ message: errorMessage })).toBe(false);
+            }
+        );
+
+        // Edge cases that need special handling
+        describe('edge cases', () => {
+            test.each([
+                ['null', null],
+                ['undefined', undefined],
+            ])('should return false for %s error', (_description, errorValue) => {
+                expect(isRetryableGitError(errorValue)).toBe(false);
+            });
+
+            test('should handle error without message property via toString', () => {
+                expect(isRetryableGitError({ toString: () => 'ETIMEDOUT' })).toBe(true);
+            });
+
+            test('should handle retryable error via toString fallback', () => {
+                expect(isRetryableGitError({ toString: () => 'repository not found' })).toBe(true);
+            });
+        });
+    });
+
+    describe('cloneWithRetry', () => {
+        let mockClone: jest.Mock;
+        let consoleWarnSpy: jest.SpyInstance;
+        let consoleLogSpy: jest.SpyInstance;
+        let consoleErrorSpy: jest.SpyInstance;
+
+        // Access private static method for testing
+        const cloneWithRetry = (
+            repoName: string,
+            remoteUrl: string,
+            toPath: string,
+            options: string[],
+            maxRetries: number
+        ): Promise<void> => {
+            return (Repository as any)['cloneWithRetry'](repoName, remoteUrl, toPath, options, maxRetries);
+        };
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+            jest.useFakeTimers();
+
+            mockClone = jest.fn();
+            mockedSimpleGit.simpleGit.mockReturnValue({
+                clone: mockClone
+            } as any);
+
+            consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+            consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+            consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+            consoleWarnSpy.mockRestore();
+            consoleLogSpy.mockRestore();
+            consoleErrorSpy.mockRestore();
+        });
+
+        test('should succeed on first attempt without retries', async () => {
+            mockClone.mockImplementation((_url, _path, _opts, callback) => {
+                callback(null);
+            });
+
+            await cloneWithRetry('test-repo', 'https://example.com/repo.git', '/tmp/repo', [], 3);
+
+            expect(mockClone).toHaveBeenCalledTimes(1);
+            expect(consoleWarnSpy).not.toHaveBeenCalled();
+        });
+
+        test('should retry on retryable error and succeed', async () => {
+            let attempts = 0;
+            mockClone.mockImplementation((_url, _path, _opts, callback) => {
+                attempts++;
+                if (attempts === 1) {
+                    callback(new Error('ETIMEDOUT'));
+                } else {
+                    callback(null);
+                }
+            });
+
+            const clonePromise = cloneWithRetry('test-repo', 'https://example.com/repo.git', '/tmp/repo', [], 3);
+
+            // First attempt fails, wait for retry delay (2^1 * 1000 = 2000ms)
+            await jest.advanceTimersByTimeAsync(2000);
+
+            await clonePromise;
+
+            expect(mockClone).toHaveBeenCalledTimes(2);
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                '[test-repo]:',
+                expect.stringContaining('Clone failed with transient error (attempt 1/3)')
+            );
+            expect(consoleLogSpy).toHaveBeenCalledWith(
+                '[test-repo]:',
+                expect.stringContaining('Clone succeeded on attempt 2')
+            );
+        });
+
+        test('should throw after exhausting all retries on retryable error', async () => {
+            mockClone.mockImplementation((_url, _path, _opts, callback) => {
+                callback(new Error('ETIMEDOUT'));
+            });
+
+            const clonePromise = cloneWithRetry('test-repo', 'https://example.com/repo.git', '/tmp/repo', [], 3);
+
+            // Attach rejection handler immediately to prevent unhandled rejection
+            let caughtError: Error | null = null;
+            clonePromise.catch((err: Error) => {
+                caughtError = err;
+            });
+
+            // Advance through all retry delays
+            await jest.runAllTimersAsync();
+
+            // Wait for the promise to settle
+            await expect(clonePromise).rejects.toThrow('ETIMEDOUT');
+
+            expect(mockClone).toHaveBeenCalledTimes(3);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                '[test-repo]:',
+                'Clone failed after 3 attempts'
+            );
+            expect(caughtError).not.toBeNull();
+        });
+
+        test('should fail immediately on non-retryable error', async () => {
+            mockClone.mockImplementation((_url, _path, _opts, callback) => {
+                callback(new Error('Permission denied (publickey)'));
+            });
+
+            await expect(
+                cloneWithRetry('test-repo', 'https://example.com/repo.git', '/tmp/repo', [], 3)
+            ).rejects.toThrow('Permission denied (publickey)');
+
+            expect(mockClone).toHaveBeenCalledTimes(1);
+            expect(consoleWarnSpy).not.toHaveBeenCalled();
+        });
+
+        test('should use exponential backoff delays', async () => {
+            let attempts = 0;
+            mockClone.mockImplementation((_url, _path, _opts, callback) => {
+                attempts++;
+                if (attempts < 4) {
+                    callback(new Error('ETIMEDOUT'));
+                } else {
+                    callback(null);
+                }
+            });
+
+            const clonePromise = cloneWithRetry('test-repo', 'https://example.com/repo.git', '/tmp/repo', [], 5);
+
+            // Verify exponential backoff: 2^1=2s, 2^2=4s, 2^3=8s
+            await jest.advanceTimersByTimeAsync(2000); // After attempt 1 (2^1 * 1000)
+            expect(mockClone).toHaveBeenCalledTimes(2);
+
+            await jest.advanceTimersByTimeAsync(4000); // After attempt 2 (2^2 * 1000)
+            expect(mockClone).toHaveBeenCalledTimes(3);
+
+            await jest.advanceTimersByTimeAsync(8000); // After attempt 3 (2^3 * 1000)
+            expect(mockClone).toHaveBeenCalledTimes(4);
+
+            await clonePromise;
+        });
+
+        // Parameterized tests for different retryable error types
+        const retryableCloneErrors: [string, string][] = [
+            ['HTTP 404', 'HTTP 404: Not Found'],
+            ['repository not found', 'remote: repository not found'],
+            ['ECONNRESET', 'read ECONNRESET'],
+        ];
+
+        test.each(retryableCloneErrors)(
+            'should retry on %s error and succeed',
+            async (_description, errorMessage) => {
+                let attempts = 0;
+                mockClone.mockImplementation((_url, _path, _opts, callback) => {
+                    attempts++;
+                    if (attempts === 1) {
+                        callback(new Error(errorMessage));
+                    } else {
+                        callback(null);
+                    }
+                });
+
+                const clonePromise = cloneWithRetry('test-repo', 'https://example.com/repo.git', '/tmp/repo', [], 3);
+
+                await jest.advanceTimersByTimeAsync(2000);
+                await clonePromise;
+
+                expect(mockClone).toHaveBeenCalledTimes(2);
+            }
+        );
+
+        test('should work with maxRetries of 1 (no retries)', async () => {
+            mockClone.mockImplementation((_url, _path, _opts, callback) => {
+                callback(new Error('ETIMEDOUT'));
+            });
+
+            await expect(
+                cloneWithRetry('test-repo', 'https://example.com/repo.git', '/tmp/repo', [], 1)
+            ).rejects.toThrow('ETIMEDOUT');
+
+            expect(mockClone).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('delay helper', () => {
+        // Access private static method for testing
+        const delay = (ms: number): Promise<void> => {
+            return (Repository as any)['delay'](ms);
+        };
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test('should resolve after specified delay', async () => {
+            const delayPromise = delay(1000);
+
+            jest.advanceTimersByTime(999);
+            expect(jest.getTimerCount()).toBe(1);
+
+            jest.advanceTimersByTime(1);
+            await delayPromise;
+
+            expect(jest.getTimerCount()).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
Resolves [PFM-ISSUE-31861](https://base.cplace.io/pages/3jjtkh6mmv3cojbpymddg94iu/PFM-ISSUE-31861-Fix-intermittent-HTTP-404-errors-in-parent-repo-cloning-with-retry-mechanism)

## Summary

Implements a retry mechanism for git clone operations to handle transient network errors (HTTP 404, timeouts, connection issues) that intermittently cause build failures.

### Changes
- Add configurable `--max-attempts` option for clone/update commands (default: 1, no retries)
- Implement exponential backoff between retries (2s, 4s, 8s, ...)
- Detect transient errors (HTTP 404, connection timeouts, connection refused, connection reset)
- Refactor `Repository.clone()` method for improved readability using async/await

### Test plan
- [x] All existing tests pass
- [x] Build succeeds with `npm run dev`
- [x] New retry logic tests added
- [ ] Manual testing with clone operations