### PR TITLE
PFM-ISSUE-32338: Enable OIDC trusted publishing for cplace-cli and cplace-asc on npmjs.org

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -3,22 +3,50 @@ on:
   release:
     types: [created]
 
-permissions:
-  id-token: write  # Required for OIDC
-  contents: read
-
 jobs:
   build:
     name: Publish package to NPM
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "18.11.0"
           cache: 'npm'
           registry-url: "https://registry.npmjs.org"
-      - name: NPM Install
-        run: npm install
-      - name: NPM Publish
-        run: npm publish
+
+      - name: NPM Install and build
+        run: |
+          npm install
+          npm run prepare
+
+      - name: Create package tarball
+        run: npm pack
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: '*.tgz'
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: package
+
+      - name: Setup Node 24 with npm 11
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish tarball with OIDC
+        run: npm publish *.tgz

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -22,4 +22,3 @@ jobs:
         run: npm install
       - name: NPM Publish
         run: npm publish
-        

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -30,7 +30,8 @@ jobs:
           name: package
           path: '*.tgz'
 
-  publish:
+  trusted_publish:
+    name: Trusted Publish to NPM
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -3,6 +3,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     name: Publish package to NPM
@@ -11,12 +15,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.11.0"
+          node-version: "24"
           cache: 'npm'
           registry-url: "https://registry.npmjs.org"
       - name: NPM Install
         run: npm install
       - name: NPM Publish
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        


### PR DESCRIPTION
Resolves [PFM-ISSUE-32338](https://base.cplace.io/pages/arpi39yf67jp3kgh5c3xtri2v/PFM-ISSUE-32338-Enable-OIDC-trusted-publishing-for-cplace-cli-and-cplace-asc-on-npmjs.org)